### PR TITLE
patroni_replication_username in hba

### DIFF
--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -321,7 +321,7 @@ pending_restart: false
 postgresql_pg_hba:
   - { type: "local", database: "all", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "{{ pgbouncer_auth_username }}", address: "", method: "trust" } # required for pgbouncer auth_user
-  - { type: "local", database: "replication", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
+  - { type: "local", database: "replication", user: "{{ patroni_replication_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "all", address: "", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "127.0.0.1/32", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "::1/128", method: "{{ postgresql_password_encryption_algorithm }}" }


### PR DESCRIPTION
Across many versions there is such line in postgresql_pg_hba:
`  - { type: "local", database: "replication", user: "{{ patroni_replication_username }}", address: "", method: "trust" }`

I assume it's a typo and it needs to be:
`  - { type: "local", database: "replication", user: "{{ patroni_replication_username }}", address: "", method: "trust" }`

This is the only critical place as far as I can see but I'd highly suggest to double-check me.