### PR TITLE
pgBackRest: update configuration file include-path option

### DIFF
--- a/automation/roles/pgbackrest/templates/pgbackrest.server.conf.j2
+++ b/automation/roles/pgbackrest/templates/pgbackrest.server.conf.j2
@@ -4,5 +4,5 @@
 {% endfor %}
 
 # Include stanzas configuration files
-include-path = {{ pgbackrest_conf_file | dirname }}/conf.d
+repo1-host-config-include-path = {{ pgbackrest_conf_file | dirname }}/conf.d
 


### PR DESCRIPTION
This PR is intended to fix the pgbackrest.conf configuration file in the 'include-path' variable according to the latest version of the documentation https://pgbackrest.org/configuration.html#section-repository/option-repo-host-config-include-path.

This change fix the warning from pgbackrest when trying to execute commands from the pgbackrest host:
```
postgres@backuper:~$ pgbackrest --stanza=test-cluster check
P00   WARN: configuration file contains invalid option 'include-path'
``` 