### PR TITLE
Add Upgrade Support for Standby Cluster

### DIFF
--- a/.github/workflows/molecule_pg_upgrade.yml
+++ b/.github/workflows/molecule_pg_upgrade.yml
@@ -18,13 +18,10 @@ jobs:
           - distro: debian11
             tag: latest
             namespace: geerlingguy
-          - distro: debian10
+          - distro: ubuntu2404
             tag: latest
             namespace: geerlingguy
           - distro: ubuntu2204
-            tag: latest
-            namespace: geerlingguy
-          - distro: ubuntu2004
             tag: latest
             namespace: geerlingguy
           - distro: rockylinux8

--- a/automation/roles/upgrade/README.md
+++ b/automation/roles/upgrade/README.md
@@ -187,22 +187,10 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
 - Backup the patroni.yml configuration file
 - Edit the patroni.yml configuration file
   - **Update parameters**: `data_dir`, `bin_dir`, `config_dir`
-  - **Check if the 'standby_cluster' parameter is specified**
-    - Remove parameters: `standby_cluster` (if exists)
+  - **Prepare the PostgreSQL parameters**
+    - Notes: Removed or renamed parameters
+  - **Remove 'standby_cluster' parameter (if exists)**
     - Notes: To support upgrades in the Patroni Standby Cluster
-  - **Prepare the PostgreSQL parameters** (removed or renamed parameters)
-    - Check if the '`replacement_sort_tuples`' parameter is specified (removed in PG 11)
-      - remove parameter: 'replacement_sort_tuples' (if exists)
-    - Check if the '`default_with_oids`' parameter is specified (removed in PG 12)
-      - remove parameter: 'default_with_oids' (if exists)
-    - Check if the '`wal_keep_segments`' parameter is specified (removed in PG 13)
-      - replace parameter: 'wal_keep_segments' to '`wal_keep_size`'
-    - Check if the '`operator_precedence_warning`' parameter is specified" (removed in PG 14)
-      - remove parameter: 'operator_precedence_warning' (if exists)
-    - Check if the '`vacuum_cleanup_index_scale_factor`' parameter is specified (removed in PG 14)
-      - remove parameter: 'vacuum_cleanup_index_scale_factor' (if exists)
-    - Check if the '`stats_temp_directory`' parameter is specified (removed in PG 15)
-      - remove parameter: 'stats_temp_directory' (if exists)
 - **Copy pg_hba.conf to `pg_new_confdir`**
   - Notes: to save pg_hba rules
 

--- a/automation/roles/upgrade/tasks/update_config.yml
+++ b/automation/roles/upgrade/tasks/update_config.yml
@@ -25,26 +25,6 @@
   loop_control:
     label: '{{ item.replace }}'
 
-# To support upgrades in the Patroni Standby Cluster.
-- block:  # standby_cluster
-    - name: "Edit patroni.yml | check if the 'standby_cluster' parameter is specified"
-      ansible.builtin.command: grep standby_cluster {{ patroni_config_file }}
-      register: standby_cluster_output
-      changed_when: false
-      failed_when: false
-
-    # The standby_cluster parameter will be removed from the bootstrap.dcs section (if exists)
-    # along with all the text between 'standby_cluster' and the next 'initdb' parameter
-    - name: "Edit patroni.yml | remove parameters: standby_cluster (if exists)"
-      ansible.builtin.replace:
-        path: "{{ patroni_config_file }}"
-        regexp: '^\s*standby_cluster:[^\n]*\n(.|\n)*?initdb:'
-        replace: '  initdb:'
-      when: standby_cluster_output.stdout | length > 0
-  when:
-    - patroni_standby_cluster.host is defined
-    - patroni_standby_cluster.host | length > 0
-
 # Prepare the parameters for PostgreSQL (removed or renamed parameters).
 
 - block:  # replacement_sort_tuples (removed in the PG 11)
@@ -268,6 +248,17 @@
     - pg_old_version|int <= 16 and pg_new_version|int >= 17
 
 # TODO: Prepare the parameters for PostgreSQL 18 and etc.
+
+# To support upgrades in the Patroni Standby Cluster.
+- name: "Edit patroni.yml | remove parameter: standby_cluster (if exists)"
+  ansible.builtin.replace:
+    path: "{{ patroni_config_file }}"
+    regexp: '^\s*standby_cluster:[^\n]*\n(.|\n)*?initdb:'
+    replace: '  initdb:'
+
+- name: "Remove 'standby_cluster' parameter from DCS (if exists)"
+  ansible.builtin.command: patronictl -c {{ patroni_config_file }} edit-config -s standby_cluster=null --force
+  when: inventory_hostname in groups['primary']
 
 # Copy the pg_hba.conf file to a new PostgreSQL to save pg_hba rules.
 - name: "Copy pg_hba.conf to {{ pg_new_confdir }}"


### PR DESCRIPTION
We have now automated the upgrade process for the Patroni Standby Cluster. This allows us to perform upgrades on the cluster copy without impacting the main cluster.

However, this approach requires a preliminary (manual) shutdown of traffic to the main cluster to ensure no recent data changes are lost.

P.S. A zero-downtime upgrade using the blue/green strategy is planned as part of [issue](https://github.com/vitabaks/autobase/issues/537) and will be included in one of the future versions of Autobase.