### PR TITLE
Upgrade: Add PATH environment for patronictl command

### DIFF
--- a/automation/roles/upgrade/tasks/update_config.yml
+++ b/automation/roles/upgrade/tasks/update_config.yml
@@ -258,6 +258,8 @@
 
 - name: "Remove 'standby_cluster' parameter from DCS (if exists)"
   ansible.builtin.command: patronictl -c {{ patroni_config_file }} edit-config -s standby_cluster=null --force
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
   when: inventory_hostname in groups['primary']
 
 # Copy the pg_hba.conf file to a new PostgreSQL to save pg_hba rules.


### PR DESCRIPTION
Fixed:

```
  TASK [upgrade : Remove 'standby_cluster' parameter from DCS (if exists)] *******
 fatal: [10.172.2.20]: FAILED! => {"changed": false, "cmd": "patronictl -c /etc/patroni/patroni.yml edit-config -s standby_cluster=null --force", "msg": "[Errno 2] No such file or directory: b'patronictl': b'patronictl'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

The problem was reproduced on Oracle Linux 8 - https://github.com/vitabaks/autobase/actions/runs/12208193286/job/34060985583