### PR TITLE
Update vip-manager to v3.0.0; Patroni REST API support

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -13,7 +13,7 @@
         sysctl_set: false # Added to prevent test failures in CI.
         nameservers: ["8.8.8.8", "9.9.9.9"]
         timezone: "Etc/UTC"
-        with_haproxy_load_balancing: true
+        with_haproxy_load_balancing: "{{ [true, false] | random }}"
         dcs_type: "{{ ['etcd', 'consul'] | random }}" # Set 'dcs_type' to either 'etcd' or 'consul' randomly
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
@@ -33,6 +33,14 @@
         dest: "../../vars/dcs_type.yml"
       delegate_to: localhost
       run_once: true # noqa run-once
+
+    - name: Set variables for vip-manager test
+      ansible.builtin.set_fact:
+        cluster_vip: "10.172.0.200"
+        vip_manager_dcs_type: "{{ [dcs_type, 'patroni'] | random }}" # Randomly choose between dcs_type value or 'patroni'
+      delegate_to: localhost
+      run_once: true # noqa run-once
+      when: not with_haproxy_load_balancing | bool
 
     # Consul package for OracleLinux missing in HashiCorp repository
     # Only the installation of a binary file is supported

--- a/automation/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/automation/roles/vip-manager/templates/vip-manager.yml.j2
@@ -3,10 +3,15 @@
 # time (in milliseconds) after which vip-manager wakes up and checks if it needs to register or release ip addresses.
 interval: {{ vip_manager_interval }}
 
+{% if vip_manager_dcs_type | default(dcs_type) == 'patroni' %}
+trigger-key: "/leader"
+trigger-value: 200
+{% else %}
 # the etcd or consul key which vip-manager will regularly poll.
 trigger-key: "/{{ patroni_etcd_namespace | default('service') }}/{{ patroni_cluster_name }}/leader"
 # if the value of the above key matches the trigger-value (often the hostname of this host), vip-manager will try to add the virtual ip address to the interface specified in Iface
 trigger-value: "{{ ansible_hostname }}"
+{% endif %}
 
 ip: {{ vip_manager_ip }} # the virtual ip address to manage
 netmask: {{ vip_manager_mask }} # netmask for the virtual ip
@@ -15,46 +20,50 @@ interface: {{ vip_manager_iface }} # interface to which the virtual ip will be a
 # how the virtual ip should be managed. we currently support "ip addr add/remove" through shell commands or the Hetzner api
 hosting-type: basic # possible values: basic, or hetzner.
 
-dcs-type: {{ dcs_type }} # etcd or consul
+dcs-type: {{ vip_manager_dcs_type | default(dcs_type) }} # etcd, consul or patroni
+
 # a list that contains all DCS endpoints to which vip-manager could talk.
-{% if not dcs_exists|bool and dcs_type == 'etcd' %}
+{% if not dcs_exists|bool and vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
 dcs-endpoints:
 {% for host in groups['etcd_cluster'] %}
   - http://{{ hostvars[host]['inventory_hostname'] }}:2379
 {% endfor %}
 {% endif %}
-{% if dcs_exists|bool and dcs_type == 'etcd' %}
+{% if dcs_exists|bool and vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
 dcs-endpoints:
 {% for etcd_hosts in patroni_etcd_hosts %}
   - {{ patroni_etcd_protocol | default('http', true) }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
 {% endfor %}
+{% endif %}
 
+{% if vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
 {% if patroni_etcd_username | default("") | length > 0 %}
-etcd-user: {{ patroni_etcd_username | default("") }}
+etcd-user: {{ patroni_etcd_username }}
 {% endif %}
 {% if patroni_etcd_password | default("") | length > 0 %}
 etcd-password: {{ patroni_etcd_password }}
 {% endif %}
+# when etcd-ca-file is specified, TLS connections to the etcd endpoints will be used.
+{% if patroni_etcd_ca_file | default("") | length > 0 %}
+etcd-ca-file: {{ patroni_etcd_ca_file }}
+{% endif %}
+# when etcd-cert-file and etcd-key-file are specified, we will authenticate at the etcd endpoints using this certificate and key.
+{% if patroni_etcd_cert_file | default("") | length > 0 %}
+etcd-cert-file: {{ patroni_etcd_cert_file }}
+{% endif %}
+{% if patroni_etcd_key_file | default("") | length > 0 %}
+etcd-key-file: {{ patroni_etcd_key_file }}
+{% endif %}
 {% endif %}
 
-  # consul will always only use the first entry from this list.
-  # For consul, you'll obviously need to change the port to 8500.
-
-#etcd-user: "patroni"
-#etcd-password: "Julian's secret password"
-
-# when etcd-ca-file is specified, TLS connections to the etcd endpoints will be used.
-#etcd-ca-file: "/path/to/etcd/trusted/ca/file"
-# when etcd-cert-file and etcd-key-file are specified, we will authenticate at the etcd endpoints using this certificate and key.
-#etcd-cert-file: "/path/to/etcd/client/cert/file"
-#etcd-key-file: "/path/to/etcd/client/key/file"
-
+{% if vip_manager_dcs_type | default(dcs_type) == 'consul' %}
 # don't worry about parameter with a prefix that doesn't match the endpoint_type. You can write anything there, I won't even look at it.
-#consul-token: "Julian's secret token"
+consul-token: "{{ consul_token | default('') }}"
+{% endif %}
 
 # how often things should be retried and how long to wait between retries. (currently only affects arpClient)
 retry-num: 2
-retry-after: 250  #in milliseconds
+retry-after: 250  # in milliseconds
 
 # verbose logs (currently only supported for hetzner)
 verbose: false

--- a/automation/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/automation/roles/vip-manager/templates/vip-manager.yml.j2
@@ -23,17 +23,27 @@ hosting-type: basic # possible values: basic, or hetzner.
 dcs-type: {{ vip_manager_dcs_type | default(dcs_type) }} # etcd, consul or patroni
 
 # a list that contains all DCS endpoints to which vip-manager could talk.
-{% if not dcs_exists|bool and vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
+{% if vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
+{% if not dcs_exists | bool %}
 dcs-endpoints:
 {% for host in groups['etcd_cluster'] %}
   - http://{{ hostvars[host]['inventory_hostname'] }}:2379
 {% endfor %}
-{% endif %}
-{% if dcs_exists|bool and vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
+{% else %}
 dcs-endpoints:
 {% for etcd_hosts in patroni_etcd_hosts %}
   - {{ patroni_etcd_protocol | default('http', true) }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
 {% endfor %}
+{% endif %}
+{% endif %}
+{% if vip_manager_dcs_type | default(dcs_type) == 'consul' %}
+dcs-endpoints:
+{% for host in groups['consul_cluster'] %}
+  - http://{{ hostvars[host]['inventory_hostname'] }}:8500
+{% endfor %}
+{% if consul_token | default("") | length > 0 %}
+consul-token: "{{ consul_token | default('') }}"
+{% endif %}
 {% endif %}
 
 {% if vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
@@ -54,11 +64,6 @@ etcd-cert-file: {{ patroni_etcd_cert_file }}
 {% if patroni_etcd_key_file | default("") | length > 0 %}
 etcd-key-file: {{ patroni_etcd_key_file }}
 {% endif %}
-{% endif %}
-
-{% if vip_manager_dcs_type | default(dcs_type) == 'consul' %}
-# don't worry about parameter with a prefix that doesn't match the endpoint_type. You can write anything there, I won't even look at it.
-consul-token: "{{ consul_token | default('') }}"
 {% endif %}
 
 # how often things should be retried and how long to wait between retries. (currently only affects arpClient)

--- a/automation/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/automation/roles/vip-manager/templates/vip-manager.yml.j2
@@ -22,8 +22,8 @@ hosting-type: basic # possible values: basic, or hetzner.
 
 dcs-type: {{ vip_manager_dcs_type | default(dcs_type) }} # etcd, consul or patroni
 
-# a list that contains all DCS endpoints to which vip-manager could talk.
 {% if vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
+# a list that contains all DCS endpoints to which vip-manager could talk.
 {% if not dcs_exists | bool %}
 dcs-endpoints:
 {% for host in groups['etcd_cluster'] %}
@@ -37,10 +37,21 @@ dcs-endpoints:
 {% endif %}
 {% endif %}
 {% if vip_manager_dcs_type | default(dcs_type) == 'consul' %}
+# A list that contains all DCS endpoints to which vip-manager could talk.
 dcs-endpoints:
-{% for host in groups['consul_instances'] %}
+{% if not dcs_exists | bool %}
+  {% if consul_client_address == '127.0.0.1' %}
+  - http://127.0.0.1:8500
+  {% else %}
+  {% for host in groups['consul_instances'] %}
   - http://{{ hostvars[host]['inventory_hostname'] }}:8500
-{% endfor %}
+  {% endfor %}
+  {% endif %}
+{% else %}
+  {% for consul_host in consul_join %}
+  - http://{{ consul_host }}:8500
+  {% endfor %}
+{% endif %}
 {% if consul_token | default("") | length > 0 %}
 consul-token: "{{ consul_token | default('') }}"
 {% endif %}
@@ -53,12 +64,12 @@ etcd-user: {{ patroni_etcd_username | default("") }}
 {% if patroni_etcd_password | default("") | length > 0 %}
 etcd-password: {{ patroni_etcd_password | default("") }}
 {% endif %}
-# when etcd-ca-file is specified, TLS connections to the etcd endpoints will be used.
 {% if patroni_etcd_ca_file | default("") | length > 0 %}
+# when etcd-ca-file is specified, TLS connections to the etcd endpoints will be used.
 etcd-ca-file: {{ patroni_etcd_ca_file | default("") }}
 {% endif %}
-# when etcd-cert-file and etcd-key-file are specified, we will authenticate at the etcd endpoints using this certificate and key.
 {% if patroni_etcd_cert_file | default("") | length > 0 %}
+# when etcd-cert-file and etcd-key-file are specified, we will authenticate at the etcd endpoints using this certificate and key.
 etcd-cert-file: {{ patroni_etcd_cert_file | default("") }}
 {% endif %}
 {% if patroni_etcd_key_file | default("") | length > 0 %}

--- a/automation/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/automation/roles/vip-manager/templates/vip-manager.yml.j2
@@ -38,7 +38,7 @@ dcs-endpoints:
 {% endif %}
 {% if vip_manager_dcs_type | default(dcs_type) == 'consul' %}
 dcs-endpoints:
-{% for host in groups['consul_cluster'] %}
+{% for host in groups['consul_instances'] %}
   - http://{{ hostvars[host]['inventory_hostname'] }}:8500
 {% endfor %}
 {% if consul_token | default("") | length > 0 %}
@@ -48,21 +48,21 @@ consul-token: "{{ consul_token | default('') }}"
 
 {% if vip_manager_dcs_type | default(dcs_type) == 'etcd' %}
 {% if patroni_etcd_username | default("") | length > 0 %}
-etcd-user: {{ patroni_etcd_username }}
+etcd-user: {{ patroni_etcd_username | default("") }}
 {% endif %}
 {% if patroni_etcd_password | default("") | length > 0 %}
-etcd-password: {{ patroni_etcd_password }}
+etcd-password: {{ patroni_etcd_password | default("") }}
 {% endif %}
 # when etcd-ca-file is specified, TLS connections to the etcd endpoints will be used.
 {% if patroni_etcd_ca_file | default("") | length > 0 %}
-etcd-ca-file: {{ patroni_etcd_ca_file }}
+etcd-ca-file: {{ patroni_etcd_ca_file | default("") }}
 {% endif %}
 # when etcd-cert-file and etcd-key-file are specified, we will authenticate at the etcd endpoints using this certificate and key.
 {% if patroni_etcd_cert_file | default("") | length > 0 %}
-etcd-cert-file: {{ patroni_etcd_cert_file }}
+etcd-cert-file: {{ patroni_etcd_cert_file | default("") }}
 {% endif %}
 {% if patroni_etcd_key_file | default("") | length > 0 %}
-etcd-key-file: {{ patroni_etcd_key_file }}
+etcd-key-file: {{ patroni_etcd_key_file | default("") }}
 {% endif %}
 {% endif %}
 

--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -85,7 +85,7 @@ vip_manager_interval: "1000"  # time (in milliseconds) after which vip-manager w
 vip_manager_iface: "{{ vip_interface }}"  # interface to which the virtual ip will be added
 vip_manager_ip: "{{ cluster_vip }}"  # the virtual ip address to manage
 vip_manager_mask: "24"  # netmask for the virtual ip
-
+vip_manager_dcs_type: "{{ dcs_type }}"  # etcd, consul or patroni
 
 # DCS (Distributed Consensus Store)
 dcs_exists: false  # or 'true' if you don't want to deploy a new etcd cluster

--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -79,7 +79,7 @@ keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last
 # virtual_router_id - must be unique in the network (available values are 0..255).
 
 # vip-manager (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'false')
-vip_manager_version: "2.6.0"  # version to install
+vip_manager_version: "3.0.0"  # version to install
 vip_manager_conf: "/etc/patroni/vip-manager.yml"
 vip_manager_interval: "1000"  # time (in milliseconds) after which vip-manager wakes up and checks if it needs to register or release ip addresses.
 vip_manager_iface: "{{ vip_interface }}"  # interface to which the virtual ip will be added

--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -124,6 +124,7 @@ consul_enable_local_script_checks: true  # Enable them when they are defined in 
 consul_ui: false  # Enable the consul UI?
 consul_syslog_enable: true  # Enable logging to syslog
 consul_iface: "{{ ansible_default_ipv4.interface }}"  # specify the interface name with a Private IP (ex. "enp7s0")
+consul_client_address: '127.0.0.1'  # Client address. Affects DNS, HTTP, HTTPS, and gRPC client interfaces.
 # TLS
 # You can enable TLS encryption by dropping a CA certificate, server certificate, and server key in roles/consul/files/
 consul_tls_enable: false
@@ -135,6 +136,8 @@ consul_recursors: []  # List of upstream DNS servers
 consul_dnsmasq_enable: true  # Enable DNS forwarding with Dnsmasq
 consul_dnsmasq_cache: 0  # dnsmasq cache-size (0 - disable caching)
 consul_dnsmasq_servers: "{{ nameservers }}" # Upstream DNS servers used by dnsmasq
+
+# if dcs_type: "consul" and dcs_exists: true
 consul_join: []  # List of LAN servers of an existing consul cluster, to join.
 # - "10.128.64.140"
 # - "10.128.64.142"


### PR DESCRIPTION
1. Update vip-manager to v3.0.0
2. Patroni REST API support ([details](https://www.cybertec-postgresql.com/en/vip-manager-meets-patroni-rest-api/)) - optional
3. Consul DCS support - optional
4. Add test for vip-manager (installing and using different DCS types)

New variable `vip_manager_dcs_type`, default "etcd"