### PR TITLE
Allow pgvectorscale tasks execution in check_mode

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -72,7 +72,6 @@
         # enable_citus: true  # TODO Postgres 17
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
         enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
-        pgvectorscale_version: "0.5.0"  # TODO (v0.5.1 does not contain packages)
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -258,7 +258,6 @@
         dest: "/tmp/{{ pgvectorscale_archive }}"
         timeout: 60
         validate_certs: false
-      check_mode: false
 
     - name: Extract pgvectorscale package
       ansible.builtin.unarchive:
@@ -274,6 +273,7 @@
       until: apt_status is success
       delay: 5
       retries: 3
+  check_mode: false
   vars:
     pgvectorscale_repo: "https://github.com/timescale/pgvectorscale/releases/download/{{ pgvectorscale_version }}"
     pgvectorscale_archive: "pgvectorscale-{{ pgvectorscale_version }}-pg{{ pg_version | default(postgresql_version) }}-amd64.zip" # yamllint disable rule:line-length

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -250,6 +250,7 @@
             | from_json).get('tag_name')
             | replace('v', '')
           }}
+      check_mode: false
       when: pgvectorscale_version | default('latest') == 'latest'
 
     - name: Download pgvectorscale archive
@@ -258,12 +259,14 @@
         dest: "/tmp/{{ pgvectorscale_archive }}"
         timeout: 60
         validate_certs: false
+      check_mode: false
 
     - name: Extract pgvectorscale package
       ansible.builtin.unarchive:
         src: "/tmp/{{ pgvectorscale_archive }}"
         dest: "/tmp/"
         remote_src: true
+      check_mode: false
 
     # Debian (only deb packages are available)
     - name: "Install pgvectorscale v{{ pgvectorscale_version }} package"
@@ -273,7 +276,6 @@
       until: apt_status is success
       delay: 5
       retries: 3
-  check_mode: false
   vars:
     pgvectorscale_repo: "https://github.com/timescale/pgvectorscale/releases/download/{{ pgvectorscale_version }}"
     pgvectorscale_archive: "pgvectorscale-{{ pgvectorscale_version }}-pg{{ pg_version | default(postgresql_version) }}-amd64.zip" # yamllint disable rule:line-length

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -258,6 +258,7 @@
         dest: "/tmp/{{ pgvectorscale_archive }}"
         timeout: 60
         validate_certs: false
+      check_mode: false
 
     - name: Extract pgvectorscale package
       ansible.builtin.unarchive:


### PR DESCRIPTION
Added the `check_mode: false` parameter for the **pgvectorscale** tasks.

This ensures that the task executes even in `--check` mode, preventing it from being skipped and ensuring the file is downloaded. This change addresses an error where subsequent tasks fail due to the missing downloaded archive.

Fixed:

```
TASK [packages : Looking up the latest version of pgvectorscale] ***************
ok: [10.0.0.5]
TASK [packages : Download pgvectorscale archive] *******************************
changed: [10.0.0.5]
TASK [packages : Extract pgvectorscale package] ********************************
fatal: [10.0.0.5]: FAILED! => {"changed": false, "msg": "Source '/tmp/pgvectorscale-0.5.1-pg16-amd64.zip' does not exist"}
```