### PR TITLE
Auto set the number of max_worker_processes and max_parallel_workers

### DIFF
--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -315,8 +315,8 @@ postgresql_parameters:
   - { option: "wal_receiver_status_interval", value: "10s" }
   - { option: "idle_in_transaction_session_timeout", value: "10min" }  # reduce this timeout if possible
   - { option: "jit", value: "off" }
-  - { option: "max_worker_processes", value: "24" }
-  - { option: "max_parallel_workers", value: "8" }
+  - { option: "max_worker_processes", value: "{{ [ansible_processor_vcpus | int, 16] | max }}" }
+  - { option: "max_parallel_workers", value: "{{ [(ansible_processor_vcpus | int // 2), 8] | max }}" }
   - { option: "max_parallel_workers_per_gather", value: "2" }
   - { option: "max_parallel_maintenance_workers", value: "2" }
   - { option: "tcp_keepalives_count", value: "10" }


### PR DESCRIPTION
This PR introduces dynamic configuration for `max_worker_processes` and `max_parallel_workers` based on the number of vCPUs on the server:
- max_worker_processes: set to the higher value between the number of vCPUs or the minimum value of 16.
- max_parallel_workers: set to the higher value between half the number of vCPUs or the minimum value of 8.

This ensures optimal configuration for both small and large servers, adapting to the available resources while maintaining reasonable defaults.