### PR TITLE
Add support for configuring Patroni REST API request queue size

### DIFF
--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -34,6 +34,9 @@ restapi:
 #    username: username
 #    password: password
 {% endif %}
+{% if patroni_restapi_request_queue_size is defined %}
+  request_queue_size: {{ patroni_restapi_request_queue_size |int }}
+{% endif %}
 
 {% if dcs_type == 'etcd' %}
 etcd3:

--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -409,6 +409,7 @@ patroni_restapi_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ in
 patroni_restapi_port: 8008
 patroni_restapi_username: "patroni"
 patroni_restapi_password: ""  # If not defined, a password will be generated automatically during deployment.
+patroni_restapi_request_queue_size: 5
 patroni_ttl: 30
 patroni_loop_wait: 10
 patroni_retry_timeout: 10


### PR DESCRIPTION
This introduces an optional `request_queue_size` parameter for the Patroni REST API, with a default value of 5. It controls the TCP socket queue size, and once full, additional requests will receive a "Connection denied" error.

### Motivation

The proposed change addresses an availability issue in Patroni's REST API caused by the low default TCP accept queue size (`5`), which can lead to frequent listen queue overflows under high load, such as **HAProxy health checks**. By introducing a configurable `request_queue_size` option, this fix ensures greater scalability and stability for high-traffic environments while maintaining backward compatibility with the default settings

### References

https://github.com/patroni/patroni/pull/2643

https://patroni.readthedocs.io/en/latest/yaml_configuration.html#rest-api
> request_queue_size: (optional): Sets request queue size for TCP socket used by Patroni REST API. Once the queue is full, further requests get a “Connection denied” error. The default value is 5.

