### PR TITLE
Reduce HAProxy client and server timeouts to 1 minute

### DIFF
--- a/automation/vars/main.yml
+++ b/automation/vars/main.yml
@@ -42,8 +42,8 @@ haproxy_maxconn:
   master: 10000
   replica: 10000
 haproxy_timeout:
-  client: "60m"
-  server: "60m"
+  client: "60s"
+  server: "60s"
 # Optionally declare log format for haproxy.
 # Uncomment following lines (and remove extra space in front of variable definition) for JSON structured log format.
 # haproxy_log_format: "{


### PR DESCRIPTION
Reduced timeout client and timeout server from 1 hour to 1 minute. This change only affects idle connections. Active sessions where data is being transmitted are not impacted by this timeout.

This change aims to reduce the duration of idle sessions, allowing for more efficient resource utilization and better traffic distribution across replicas.

Fixed:
![2025-01-27_16-13-53](https://github.com/user-attachments/assets/58d5376e-5233-45d5-938b-dc465be3a68f)


Recommendation:
- If your application requires long-lived idle connections (e.g., WebSocket, file uploads, or long polling), and it's not important for you to evenly distribute traffic across replicas, consider increasing these timeouts to accommodate such scenarios.