### PR TITLE
Set maintenance variable for add_pgnode.yml

### DIFF
--- a/automation/add_pgnode.yml
+++ b/automation/add_pgnode.yml
@@ -21,6 +21,10 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
 
+    - name: Set maintenance variable
+      ansible.builtin.set_fact:
+        postgresql_cluster_maintenance: true
+
     - name: "[Pre-Check] Checking Linux distribution"
       ansible.builtin.fail:
         msg: "{{ ansible_distribution }} is not supported"

--- a/automation/roles/pre-checks/tasks/passwords.yml
+++ b/automation/roles/pre-checks/tasks/passwords.yml
@@ -31,11 +31,9 @@
         - pgbouncer_install | bool
         - pgbouncer_auth_user | bool
         - pgbouncer_auth_password | default('') | length < 1
-  when:
-    - not (postgresql_cluster_maintenance | default(false) | bool) # exclude for config_pgcluster.yml
-    - not (new_node | default(false) | bool) # exclude for add_pgnode.yml
+  when: not (postgresql_cluster_maintenance | default(false) | bool) # exclude for config_pgcluster.yml and add_pgnode.yml
 
-# Get current passwords (if not defined) - for config_pgcluster.yml
+# Get current passwords (if not defined) - for config_pgcluster.yml and add_pgnode.yml
 - block:
     - name: Get patroni superuser password
       ansible.builtin.shell: |
@@ -90,6 +88,4 @@
       ansible.builtin.set_fact:
         patroni_restapi_password: "{{ patroni_restapi_password_result.stdout }}"
       when: patroni_restapi_password_result.stdout is defined
-  when:
-    - (postgresql_cluster_maintenance | default(false) | bool)
-      or (new_node | default(false) | bool) # include for add_pgnode.yml
+  when: postgresql_cluster_maintenance | default(false) | bool

--- a/automation/roles/pre-checks/tasks/patroni.yml
+++ b/automation/roles/pre-checks/tasks/patroni.yml
@@ -16,7 +16,7 @@
         - pgdata_initialized.stat.exists
   when:
     - not postgresql_exists | bool
-    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
+    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml and add_pgnode.yml
 
 # when postgresql exists
 - block:
@@ -33,4 +33,4 @@
         - not pgdata_initialized.stat.exists
   when:
     - postgresql_exists | bool
-    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
+    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml and add_pgnode.yml


### PR DESCRIPTION
Set maintenance variable for add_pgnode.yml playbook.

This change disables certain pre-checks in the PostgreSQL node addition procedure and removes the need to explicitly set the postgresql_exists variable for each host in the inventory file when scaling the cluster.

Fixed:

```
TASK [pre-checks : PostgreSQL | data directory check result] *******************
fatal: [10.172.0.20]: FAILED! => {"changed": false, "msg": "Whoops! data directory /pgdata/17/main is already initialized"}
fatal: [10.172.0.21]: FAILED! => {"changed": false, "msg": "Whoops! data directory /pgdata/17/main is already initialized"}
fatal: [10.172.0.22]: FAILED! => {"changed": false, "msg": "Whoops! data directory /pgdata/17/main is already initialized"}
```