### PR TITLE
Change log file path for pre/post deploy commands to /var/tmp

### DIFF
--- a/automation/deploy_pgcluster.yml
+++ b/automation/deploy_pgcluster.yml
@@ -139,7 +139,7 @@
           when: pre_deploy_command_print | default(false) | bool
 
         - name: Run pre-deploy command
-          ansible.builtin.shell: "{{ pre_deploy_command }} > /tmp/pre_deploy_command.log 2>&1"
+          ansible.builtin.shell: "{{ pre_deploy_command }} > {{ pre_deploy_command_log | default('/var/tmp/pre_deploy_command.log') }} 2>&1"
           args:
             executable: /bin/bash
           register: pre_deploy_result
@@ -165,8 +165,8 @@
             - item.ansible_job_id is defined
 
         - name: Get pre-deploy command log
-          ansible.builtin.command: cat /tmp/pre_deploy_command.log
-          register: pre_deploy_command_log
+          ansible.builtin.command: "cat {{ pre_deploy_command_log | default('/var/tmp/pre_deploy_command.log') }}"
+          register: pre_deploy_log_content
           delegate_to: "{{ item }}"
           loop: "{{ pre_deploy_command_hosts.split(',') | map('extract', groups) | list | flatten }}"
           changed_when: false
@@ -175,11 +175,11 @@
         - name: Print pre-deploy command result
           ansible.builtin.debug:
             msg: "{{ item.stdout_lines }}"
-          loop: "{{ pre_deploy_command_log.results }}"
+          loop: "{{ pre_deploy_log_content.results }}"
           loop_control:
             label: "{{ item.item }}"
           when:
-            - pre_deploy_command_log.results is defined
+            - pre_deploy_log_content.results is defined
             - item.stdout_lines is defined
 
         - name: Stop if pre-deploy command failed
@@ -410,7 +410,7 @@
           when: post_deploy_command_print | default(false) | bool
 
         - name: Run post-deploy command
-          ansible.builtin.shell: "{{ post_deploy_command }} > /tmp/post_deploy_command.log 2>&1"
+          ansible.builtin.shell: "{{ post_deploy_command }} > {{ post_deploy_command_log | default('/var/tmp/post_deploy_command.log') }} 2>&1"
           args:
             executable: /bin/bash
           register: post_deploy_result
@@ -436,8 +436,8 @@
             - item.ansible_job_id is defined
 
         - name: Get post-deploy command log
-          ansible.builtin.command: cat /tmp/post_deploy_command.log
-          register: post_deploy_command_log
+          ansible.builtin.command: "cat {{ post_deploy_command_log | default('/var/tmp/post_deploy_command.log') }}"
+          register: post_deploy_log_content
           delegate_to: "{{ item }}"
           loop: "{{ post_deploy_command_hosts.split(',') | map('extract', groups) | list | flatten }}"
           changed_when: false
@@ -446,11 +446,11 @@
         - name: Print post-deploy command result
           ansible.builtin.debug:
             msg: "{{ item.stdout_lines }}"
-          loop: "{{ post_deploy_command_log.results }}"
+          loop: "{{ post_deploy_log_content.results }}"
           loop_control:
             label: "{{ item.item }}"
           when:
-            - post_deploy_command_log.results is defined
+            - post_deploy_log_content.results is defined
             - item.stdout_lines is defined
 
         - name: Stop if post-deploy command failed

--- a/automation/vars/system.yml
+++ b/automation/vars/system.yml
@@ -236,11 +236,13 @@ pre_deploy_command_timeout: 3600 # Timeout in seconds
 pre_deploy_command_hosts: "postgres_cluster" # host groups where the pre_deploy_command should be executed
 pre_deploy_command_print: true # Print the command in the ansible log
 pre_deploy_command_print_result: true # Print the result of the command execution to the ansible log
+pre_deploy_command_log: "/var/tmp/pre_deploy_command.log"
 
 post_deploy_command: "" # Command or script to be executed after the Postgres cluster deployment
 post_deploy_command_timeout: 3600 # Timeout in seconds
 post_deploy_command_hosts: "postgres_cluster" # host groups where the post_deploy_command should be executed
 post_deploy_command_print: true # Print the command in the ansible log
 post_deploy_command_print_result: true # Print the result of the command execution to the ansible log
+post_deploy_command_log: "/var/tmp/post_deploy_command.log"
 
 ...


### PR DESCRIPTION
We have changed the path for storing the log file for the pre and post deploy commands from /tmp/ to **/var/tmp** in order for this to work if the server restart is specified in the command.

Fixed:

```
TASK [Get post-deploy command log] ***************************************************************************************************************************************
failed: [10.0.0.8] (item=10.0.0.8) => {"ansible_loop_var": "item", "changed": false, "cmd": ["cat", "/tmp/post_deploy_command.log"], "delta": "0:00:00.002540", "end": "2025-02-14 11:50:10.446425", "item": "10.0.0.8", "msg": "non-zero return code", "rc": 1, "start": "2025-02-14 11:50:10.443885", "stderr": "cat: /tmp/post_deploy_command.log: No such file or directory", "stderr_lines": ["cat: /tmp/post_deploy_command.log: No such file or directory"], "stdout": "", "stdout_lines": []}
```

Variables `pre_deploy_command_log` and `post_deploy_command_log` have been added to redefine the log path.