### PR TITLE
Set LimitNOFILE for Patroni systemd service

### DIFF
--- a/automation/roles/patroni/templates/patroni.service.j2
+++ b/automation/roles/patroni/templates/patroni.service.j2
@@ -47,5 +47,7 @@ TimeoutSec=60
 # Restart the service if it crashed
 Restart=on-failure
  
+LimitNOFILE={{ patroni_systemd_limit_nofile | default(65536) }}
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds `LimitNOFILE` to the Patroni systemd service file to increase the limits for open file descriptors from 1024 to 65536. 

New variable: `patroni_systemd_limit_nofile`, default: `65536`

Fixed:

![image](https://github.com/user-attachments/assets/00ad1bc3-142c-4789-b03b-6c15adb47be6)

This change helps improve stability and prevent connection failures due to file descriptor limits.