### PR TITLE
Fix task execution by replacing run_once with host condition

### DIFF
--- a/automation/config_pgcluster.yml
+++ b/automation/config_pgcluster.yml
@@ -63,6 +63,13 @@
       changed_when: false
       when: patroni_leader_result is undefined or patroni_leader_result.status == -1
 
+  roles:
+    - role: pre-checks
+      vars:
+        minimal_ansible_version: 2.16.0
+        timescale_minimal_pg_version: 12 # if enable_timescale is defined
+
+  tasks:
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
       ansible.builtin.add_host:
         name: "{{ item }}"
@@ -101,13 +108,6 @@
         - not (pgbackrest_install | bool or wal_g_install | bool)
         - cloud_provider | default('') | lower in ['aws', 'gcp', 'azure']
         - pgbackrest_auto_conf | default(true) | bool  # to be able to disable auto backup settings
-      tags: always
-
-  roles:
-    - role: pre-checks
-      vars:
-        minimal_ansible_version: 2.16.0
-        timescale_minimal_pg_version: 12 # if enable_timescale is defined
   tags:
     - always
 

--- a/automation/roles/pre-checks/tasks/extensions.yml
+++ b/automation/roles/pre-checks/tasks/extensions.yml
@@ -4,7 +4,6 @@
 
 # pre-checks
 - name: TimescaleDB | Checking PostgreSQL version
-  run_once: true
   ansible.builtin.fail:
     msg:
       - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
@@ -14,7 +13,6 @@
     - postgresql_version | string is version(timescale_minimal_pg_version | default(12) | string, '<')
 
 - name: Timescale (pgvectorscale) | Checking PostgreSQL version
-  run_once: true
   ansible.builtin.fail:
     msg:
       - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the pgvectorscale."
@@ -24,7 +22,6 @@
     - postgresql_version | string is version(pgvectorscale_minimal_pg_version | default(13) | string, '<')
 
 - name: Timescale (pgvectorscale) | Checking supported operating system and version
-  run_once: true
   ansible.builtin.fail:
     msg:
       - "pgvectorscale is not supported on {{ ansible_distribution }} {{ ansible_distribution_release }}."
@@ -34,7 +31,6 @@
     - not (ansible_os_family == "Debian" and ansible_distribution_release in ['bookworm', 'jammy', 'noble'])
 
 - name: ParadeDB | Checking PostgreSQL version
-  run_once: true
   ansible.builtin.fail:
     msg:
       - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the ParadeDB (pg_search, pg_analytics)."
@@ -44,7 +40,6 @@
     - postgresql_version | string is version(paradedb_minimal_pg_version | default(14) | string, '<')
 
 - name: ParadeDB | Checking supported operating system and version
-  run_once: true
   ansible.builtin.fail:
     msg:
       - "ParadeDB (pg_search, pg_analytics) is not supported on {{ ansible_distribution }} {{ ansible_distribution_release }}."
@@ -58,7 +53,6 @@
 
 # shared_preload_libraries
 - name: Create a list of extensions
-  run_once: true
   ansible.builtin.set_fact:
     extensions: >-
       {{
@@ -76,7 +70,6 @@
       }}
 
 - name: Add required extensions to 'shared_preload_libraries' (if missing)
-  run_once: true
   ansible.builtin.set_fact:
     # This complex line does several things:
     # 1. It takes the current list of PostgreSQL parameters,

--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -29,12 +29,12 @@
       when: shared_buffers_unit == 'gb'
 
     - name: "HugePages | No configuration is required"
-      run_once: true
       ansible.builtin.debug:
         msg: >-
           Current shared_buffers size: {{ shared_buffers }} (less than {{ min_shared_buffers_gb | default(8) }}GB).
           No HugePages configuration is required.
       when:
+        - inventory_hostname == groups['master'][0]  # display only once
         - (shared_buffers_gb | default(0) | int) < (min_shared_buffers_gb | default(8) | int)
 
     - name: "HugePages | Get Hugepagesize value from /proc/meminfo"

--- a/automation/roles/pre-checks/tasks/main.yml
+++ b/automation/roles/pre-checks/tasks/main.yml
@@ -48,10 +48,10 @@
     - wal_g_install | bool
     - inventory_hostname in groups['postgres_cluster']
 
-- name: Perform pre-checks for extensions
-  ansible.builtin.import_tasks: extensions.yml
-  when: inventory_hostname in groups['postgres_cluster']
-
 - name: Generate passwords
   ansible.builtin.import_tasks: passwords.yml
   when: inventory_hostname in groups['postgres_cluster']
+
+- name: Perform pre-checks for extensions
+  ansible.builtin.import_tasks: extensions.yml
+  when: inventory_hostname == groups['master'][0]

--- a/automation/roles/pre-checks/tasks/passwords.yml
+++ b/automation/roles/pre-checks/tasks/passwords.yml
@@ -11,7 +11,7 @@
         - pgbouncer_auth_password
       when:
         - inventory_hostname == groups['master'][0]  # generate on master host
-        - vars[item] | default('') | length < 1      # if the password is not set
+        - vars[item] | default('') | length < 1      # if password is not set
 
     - name: Set password variables for all hosts
       ansible.builtin.set_fact:
@@ -30,11 +30,11 @@
         grep -A3 "superuser" | grep "password:" | awk '{ print $2 }' | tail -n 1
       args:
         executable: /bin/bash
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
       register: superuser_password_result
-      changed_when: false  # This tells Ansible that this task doesn't change anything
-      when: patroni_superuser_password | default('') | length < 1
+      changed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - patroni_superuser_password | default('') | length < 1
 
     - name: Get patroni replication user password
       ansible.builtin.shell: |
@@ -43,11 +43,11 @@
         grep -A3 "replication" | grep "password:" | awk '{ print $2 }' | tail -n 1
       args:
         executable: /bin/bash
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
       register: replication_password_result
-      changed_when: false  # This tells Ansible that this task doesn't change anything
-      when: patroni_replication_password | default('') | length < 1
+      changed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - patroni_replication_password | default('') | length < 1
 
     - name: Get patroni restapi password
       ansible.builtin.shell: |
@@ -56,24 +56,15 @@
         grep -A3 "authentication" | grep "password:" | awk '{ print $2 }' | tail -n 1
       args:
         executable: /bin/bash
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
       register: patroni_restapi_password_result
-      changed_when: false  # This tells Ansible that this task doesn't change anything
-      when: patroni_restapi_password | default('') | length < 1
+      changed_when: false
+      when:
+        - inventory_hostname == groups['master'][0]
+        - patroni_restapi_password | default('') | length < 1
 
-    - name: "Set variable: patroni_superuser_password"
+    - name: Set password variables for all hosts
       ansible.builtin.set_fact:
-        patroni_superuser_password: "{{ superuser_password_result.stdout }}"
-      when: superuser_password_result.stdout is defined
-
-    - name: "Set variable: patroni_replication_password"
-      ansible.builtin.set_fact:
-        patroni_replication_password: "{{ replication_password_result.stdout }}"
-      when: replication_password_result.stdout is defined
-
-    - name: "Set variable: patroni_restapi_password"
-      ansible.builtin.set_fact:
-        patroni_restapi_password: "{{ patroni_restapi_password_result.stdout }}"
-      when: patroni_restapi_password_result.stdout is defined
+        patroni_superuser_password: "{{ hostvars[groups['master'][0]]['superuser_password_result']['stdout'] | default('') }}"
+        patroni_replication_password: "{{ hostvars[groups['master'][0]]['replication_password_result']['stdout'] | default('') }}"
+        patroni_restapi_password: "{{ hostvars[groups['master'][0]]['patroni_restapi_password_result']['stdout'] | default('') }}"
   when: postgresql_cluster_maintenance | default(false) | bool

--- a/automation/roles/pre-checks/tasks/passwords.yml
+++ b/automation/roles/pre-checks/tasks/passwords.yml
@@ -62,9 +62,18 @@
         - inventory_hostname == groups['master'][0]
         - patroni_restapi_password | default('') | length < 1
 
-    - name: Set password variables for all hosts
+    - name: "Set variable: patroni_superuser_password"
       ansible.builtin.set_fact:
-        patroni_superuser_password: "{{ hostvars[groups['master'][0]]['superuser_password_result']['stdout'] | default('') }}"
-        patroni_replication_password: "{{ hostvars[groups['master'][0]]['replication_password_result']['stdout'] | default('') }}"
-        patroni_restapi_password: "{{ hostvars[groups['master'][0]]['patroni_restapi_password_result']['stdout'] | default('') }}"
+        patroni_superuser_password: "{{ hostvars[groups['master'][0]]['superuser_password_result']['stdout'] }}"
+      when: hostvars[groups['master'][0]]['superuser_password_result']['stdout'] is defined
+
+    - name: "Set variable: patroni_replication_password"
+      ansible.builtin.set_fact:
+        patroni_replication_password: "{{ hostvars[groups['master'][0]]['replication_password_result']['stdout'] }}"
+      when: hostvars[groups['master'][0]]['replication_password_result']['stdout'] is defined
+
+    - name: "Set variable: patroni_restapi_password"
+      ansible.builtin.set_fact:
+        patroni_restapi_password: "{{ hostvars[groups['master'][0]]['patroni_restapi_password_result']['stdout'] }}"
+      when: hostvars[groups['master'][0]]['patroni_restapi_password_result']['stdout'] is defined
   when: postgresql_cluster_maintenance | default(false) | bool

--- a/automation/roles/pre-checks/tasks/passwords.yml
+++ b/automation/roles/pre-checks/tasks/passwords.yml
@@ -1,36 +1,24 @@
 ---
 # Generate passwords (if not defined)
 - block:
-    - name: Generate a password for patroni superuser
+    - name: Generate the missing passwords
       ansible.builtin.set_fact:
-        patroni_superuser_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
-      when: patroni_superuser_password | default('') | length < 1
-
-    - name: Generate a password for patroni replication user
-      ansible.builtin.set_fact:
-        patroni_replication_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
-      when: patroni_replication_password | default('') | length < 1
-
-    - name: Generate a password for patroni restapi
-      ansible.builtin.set_fact:
-        patroni_restapi_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
-      when: patroni_restapi_password | default('') | length < 1
-
-    - name: Generate a password for pgbouncer auth user
-      ansible.builtin.set_fact:
-        pgbouncer_auth_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
-      run_once: true
-      delegate_to: "{{ groups['master'][0] }}"
+        "{{ item }}": "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
+      loop:
+        - patroni_superuser_password
+        - patroni_replication_password
+        - patroni_restapi_password
+        - pgbouncer_auth_password
       when:
-        - pgbouncer_install | bool
-        - pgbouncer_auth_user | bool
-        - pgbouncer_auth_password | default('') | length < 1
+        - inventory_hostname == groups['master'][0]  # generate on master host
+        - vars[item] | default('') | length < 1      # if the password is not set
+
+    - name: Set password variables for all hosts
+      ansible.builtin.set_fact:
+        patroni_superuser_password: "{{ hostvars[groups['master'][0]]['patroni_superuser_password'] }}"
+        patroni_replication_password: "{{ hostvars[groups['master'][0]]['patroni_replication_password'] }}"
+        patroni_restapi_password: "{{ hostvars[groups['master'][0]]['patroni_restapi_password'] }}"
+        pgbouncer_auth_password: "{{ hostvars[groups['master'][0]]['pgbouncer_auth_password'] }}"
   when: not (postgresql_cluster_maintenance | default(false) | bool) # exclude for config_pgcluster.yml and add_pgnode.yml
 
 # Get current passwords (if not defined) - for config_pgcluster.yml and add_pgnode.yml

--- a/automation/roles/pre-checks/tasks/pgbackrest.yml
+++ b/automation/roles/pre-checks/tasks/pgbackrest.yml
@@ -17,12 +17,12 @@
 
 # Checking parameters for working with a dedicated pgbackrest server
 - name: pgBackRest | Ensure pgbackrest host is in inventory
-  run_once: true # noqa run-once
   ansible.builtin.fail:
     msg:
       - "The 'pgbackrest_repo_host' variable is set but the 'pgbackrest' group in your inventory is empty."
       - "Please add the necessary host to the 'pgbackrest' group in your inventory."
   when:
+    - inventory_hostname == groups['master'][0]  # display only once
     - pgbackrest_repo_host | length > 0
     - groups['pgbackrest'] is undefined or groups['pgbackrest'] | length == 0
 

--- a/automation/roles/pre-checks/tasks/pgbouncer.yml
+++ b/automation/roles/pre-checks/tasks/pgbouncer.yml
@@ -3,11 +3,12 @@
 # This task sets the value for max_connections from the provided variables, defaulting to 100 if not explicitly set.
 # It loops through the 'postgresql_parameters' list and, if 'max_connections' is found in the option, it sets the 'max_connections' value accordingly.
 - name: Set max_connections from vars or use default
-  run_once: true
   ansible.builtin.set_fact:
     max_connections: "{{ (item.value | default(100)) | int }}"
-  when: item.option == "max_connections"
   loop: "{{ postgresql_parameters | default([]) }}"
+  when:
+    - inventory_hostname == groups['master'][0]
+    - item.option == "max_connections"
 
 # This task calculates the pgbouncer_pool_size for each defined pgbouncer pool.
 # The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
@@ -15,7 +16,6 @@
 # If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
 # The calculated pool size is then added to the total 'pgbouncer_pool_size'.
 - name: PgBouncer | Calculate pool_size
-  run_once: true
   ansible.builtin.set_fact:
     pgbouncer_pool_size: "{{
         (pgbouncer_pool_size | default(0) | int)
@@ -29,6 +29,7 @@
   loop: "{{ pgbouncer_pools | default([]) }}"
   loop_control:
     loop_var: pool_item
+  when: inventory_hostname == groups['master'][0]
 
 # This task computes the total pool size across all databases.
 # If 'postgresql_databases' isn't defined or is empty, 'pgbouncer_pool_size' is the total pool size.
@@ -36,7 +37,6 @@
 #   1. It checks each database against 'pgbouncer_pools'.
 #   2. For databases without a corresponding pool, it adds 'pgbouncer_default_pool_size' (or 0 if not defined) to 'pgbouncer_pool_size'.
 - name: PgBouncer | Calculate total pool_size
-  run_once: true
   ansible.builtin.set_fact:
     pgbouncer_total_pool_size: >-
       {{
@@ -49,21 +49,24 @@
         ) * (pgbouncer_default_pool_size | default(0) | int))
         * (pgbouncer_processes | default(1) | int)
       }}
-  when: pgbouncer_pool_size is defined
+  when:
+    - inventory_hostname == groups['master'][0]
+    - pgbouncer_pool_size is defined
 
 - name: PgBouncer | Show total pool_size
-  run_once: true
   ansible.builtin.debug:
     var: pgbouncer_total_pool_size
-  when: pgbouncer_total_pool_size is defined
+  when:
+    - inventory_hostname == groups['master'][0]
+    - pgbouncer_total_pool_size is defined
 
 # This task fails the playbook execution if the total pool size is greater than max_connections.
 # It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
 # If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
 - name: PgBouncer | Failed when pgbouncer_total_pool_size > max_connections
-  run_once: true
   ansible.builtin.fail:
     msg: "pgbouncer_total_pool_size: {{ pgbouncer_total_pool_size }} > max_connections: {{ max_connections }}. Need change settings"
   when:
+    - inventory_hostname == groups['master'][0]
     - pgbouncer_pools|default([]) | length > 0
     - pgbouncer_total_pool_size | int > max_connections | default(100) | int


### PR DESCRIPTION
Issue: https://github.com/vitabaks/autobase/issues/795

Replaced `run_once` and `delegate_to` with an explicit condition (`inventory_hostname == groups['master'][0]`) to ensure password generation runs on the first master node.

run_once executes on the first host in the PLAY, which may not be a PostgreSQL node if etcd is on dedicated hosts. This caused password generation to be skipped, leading to errors. The fix ensures passwords are always generated, preventing issues with empty password variables.