### PR TITLE
Change HTTP links to HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This automated database platform enables you to create and manage production-rea
 
 **Automate deployment, failover, backups, restore, upgrades, scaling, and more with ease.**
 
-You can find a version of this documentation that is searchable and also easier to navigate at [autobase.tech](http://autobase.tech)
+You can find a version of this documentation that is searchable and also easier to navigate at [autobase.tech](https://autobase.tech)
 
 ---
 
@@ -44,7 +44,7 @@ This is simple scheme without load balancing.
 
 - [**Patroni**](https://github.com/zalando/patroni) is a template for you to create your own customized, high-availability solution using Python and - for maximum accessibility - a distributed configuration store like ZooKeeper, etcd, Consul or Kubernetes. Used for automate the management of PostgreSQL instances and auto failover.
 
-- [**etcd**](https://github.com/etcd-io/etcd) is a distributed reliable key-value store for the most critical data of a distributed system. etcd is written in Go and uses the [Raft](https://raft.github.io/) consensus algorithm to manage a highly-available replicated log. It is used by Patroni to store information about the status of the cluster and PostgreSQL configuration parameters. [What is Distributed Consensus?](http://thesecretlivesofdata.com/raft/)
+- [**etcd**](https://github.com/etcd-io/etcd) is a distributed reliable key-value store for the most critical data of a distributed system. etcd is written in Go and uses the [Raft](https://raft.github.io/) consensus algorithm to manage a highly-available replicated log. It is used by Patroni to store information about the status of the cluster and PostgreSQL configuration parameters. [What is Distributed Consensus?](https://thesecretlivesofdata.com/raft/)
 
 - [**vip-manager**](https://github.com/cybertec-postgresql/vip-manager) (_optional, if the `cluster_vip` variable is specified_) is a service that gets started on all cluster nodes and connects to the DCS. If the local node owns the leader-key, vip-manager starts the configured VIP. In case of a failover, vip-manager removes the VIP on the old leader and the corresponding service on the new leader starts it there. Used to provide a single entry point (VIP) for database access.
 
@@ -69,7 +69,7 @@ List of ports when using HAProxy:
 
 ##### Components of HAProxy load balancing:
 
-- [**HAProxy**](http://www.haproxy.org/) is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. 
+- [**HAProxy**](https://www.haproxy.org/) is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. 
 
 - [**confd**](https://github.com/kelseyhightower/confd) manage local application configuration files using templates and data from etcd or consul. Used to automate HAProxy configuration file management.
 


### PR DESCRIPTION
Hey, noticed that a couple links in the README were `http://` instead of `https://`. I tried all of the links with HTTPS, and they were all valid. I assume that it wasn't a conscious choice to use HTTP.

This PR changes any HTTP links in the README to HTTPS.