### PR TITLE
fix for "Connection ifno" task

### DIFF
--- a/automation/roles/deploy-finish/tasks/main.yml
+++ b/automation/roles/deploy-finish/tasks/main.yml
@@ -131,7 +131,7 @@
           port: "{{ pgbouncer_listen_port }}"
           superuser: "{{ superuser_username }}"
           password: "{{ superuser_password }}"
-      when: not with_haproxy_load_balancing | bool
+      when: not with_haproxy_load_balancing | bool and pgbouncer_install | bool
 
     # if 'with_haproxy_load_balancing' is 'false' and 'pgbouncer_install' is 'false'
     - name: Connection info


### PR DESCRIPTION
There is mistake in "Connection info" task for next config:
with_haproxy_load_balancing: false
pgbouncer_install: false

Now with this config as result we see two "connection info":
```
TASK [Include OS-specific variables] ***************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211]

TASK [deploy-finish : Connection info] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211] => {
    "msg": {
        "address": "10.192.16.211",
        "password": "postgres",
        "port": 6432,
        "superuser": "postgres"
    }
}

TASK [deploy-finish : Connection info] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211] => {
    "msg": {
        "address": "10.192.16.211",
        "connection_string": {
            "read_only": "postgresql://postgres:postgres@10.192.16.211:5432/postgres?target_session_attrs=read-only",
            "read_write": "postgresql://postgres:postgres@10.192.16.211:5432/postgres?target_session_attrs=read-write"
        },
        "password": "postgres",
        "port": 5432,
        "superuser": "postgres"
    }
}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************************************************************
10.192.16.211              : ok=29   changed=0    unreachable=0    failed=0    skipped=49   rescued=0    ignored=0
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=241  rescued=0    ignored=0
```

With this simple fix all works correctly:
with_haproxy_load_balancing: false
pgbouncer_install: false
```
TASK [deploy-finish : Connection info] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211] => {
    "msg": {
        "address": "10.192.16.211",
        "connection_string": {
            "read_only": "postgresql://postgres:postgres@10.192.16.211:5432/postgres?target_session_attrs=read-only",
            "read_write": "postgresql://postgres:postgres@10.192.16.211:5432/postgres?target_session_attrs=read-write"
        },
        "password": "postgres",
        "port": 5432,
        "superuser": "postgres"
    }
}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************************************************************
10.192.16.211              : ok=28   changed=0    unreachable=0    failed=0    skipped=50   rescued=0    ignored=0
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=241  rescued=0    ignored=0
```

And for this config too:
with_haproxy_load_balancing: false
pgbouncer_install: true
```
TASK [Include OS-specific variables] ***************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211]

TASK [deploy-finish : Connection info] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [10.192.16.211] => {
    "msg": {
        "address": "10.192.16.211",
        "password": "postgres",
        "port": 6432,
        "superuser": "postgres"
    }
}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************************************************************
10.192.16.211              : ok=32   changed=0    unreachable=0    failed=0    skipped=46   rescued=0    ignored=0
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=241  rescued=0    ignored=0
```