### PR TITLE
Use a more flexible Ansible dependency notation

### DIFF
--- a/automation/requirements.yml
+++ b/automation/requirements.yml
@@ -1,22 +1,22 @@
 ---
 collections:
   - name: amazon.aws
-    version: "==9.3.0"
+    version: ">=9.3.0"
   - name: google.cloud
-    version: "==1.5.1"
+    version: ">=1.5.1"
   - name: azure.azcollection
-    version: "==3.3.1"
+    version: ">=3.3.1"
   - name: community.digitalocean
-    version: "==1.27.0"
+    version: ">=1.27.0"
   - name: hetzner.hcloud
-    version: "==4.3.0"
+    version: ">=4.3.0"
   - name: community.postgresql
-    version: "==3.12.0"
+    version: ">=3.12.0"
   - name: community.docker
-    version: "==4.4.0"
+    version: ">=4.4.0"
   - name: community.general
-    version: "==10.4.0"
+    version: ">=10.4.0"
   - name: ansible.posix
-    version: "==1.6.2"
+    version: ">=1.6.2"
   - name: ansible.utils
-    version: "==5.1.2"
+    version: ">=5.1.2"


### PR DESCRIPTION
Currently Ansible deps are hardcoded to a specific version.
This raises issues when installing the collection into an inventory with other roles/collections which make use of the same dependencies or if these dependencies are specified standalone.

Having dedicated versions means that all other assets must follow the ones listed in `autobase` or none will work.

I suggest to make the dependency notation more flexible by using `>=` instead of `==`. This way, users can install newer versions of the deps and in case of issues, the last tested versions are listed descriptively in the collection description.