### PR TITLE
Use file logging for patroni and reduce log level

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -460,10 +460,10 @@ patroni_slots: []
 #    plugin: "pgoutput"
 #    database: "test"
 
-patroni_log_destination: stderr # or 'logfile'
+patroni_log_destination: logfile # or 'stderr'
 # if patroni_log_destination: logfile
 patroni_log_dir: /var/log/patroni
-patroni_log_level: info
+patroni_log_level: warning
 patroni_log_traceback_level: error
 patroni_log_format: "%(asctime)s %(levelname)s: %(message)s"
 patroni_log_dateformat: ""


### PR DESCRIPTION
Reasoning:

- The current logging to `stderr` with log-level `info` causes an entry to syslog every 10s. This results in multi-GB syslog logfiles. These are usually auto-rotated multiple times, resulting in ~ 10 GB of syslog files after a few weeks. 99% of the entries look like `patroni[689]: 2025-05-03 11:47:14,989 INFO: no action. I am (pgnode2), the leader with the lock`
- Changing `patroni` log level only takes effect when `patroni_log_destination` is `logfile` as the template has a condition on it. 

If you prefer to keep the `info` level, then the logrotation `file_size` value should be increased. It is currently at 25 MB and keeps 4 files. With the amount of message written with `info`, this is not even covering a single day. 

