### PR TITLE
fix: ssh known_hosts parsing for pgbackrest role

### DIFF
--- a/.config/make/docker.mak
+++ b/.config/make/docker.mak
@@ -2,6 +2,9 @@
 TAG ?= local
 DOCKER_REGISTRY ?= autobase
 
+# Sanitize the tag by replacing slashes with hyphens for Docker compatibility
+SANITIZED_TAG := $(subst /,-,$(TAG))
+
 .PHONY: docker-lint docker-lint-console-ui docker-lint-console-api docker-lint-console-db docker-lint-console
 docker-lint: docker-lint-automation docker-lint-console-ui docker-lint-console-api docker-lint-console-db docker-lint-console ## Lint all Dockerfiles
 
@@ -34,57 +37,57 @@ docker-lint-console: ## Lint console Dockerfile (all services)
 docker-build: docker-build-automation docker-build-console-ui docker-build-console-api docker-build-console-db docker-build-console ## Build for all Docker images
 
 docker-build-automation: ## Build automation image
-	@echo "Build automation docker image with tag $(TAG)";
-	docker build --no-cache --platform linux/amd64 --tag automation:$(TAG) --file automation/Dockerfile .
+	@echo "Build automation docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))";
+	docker build --no-cache --platform linux/amd64 --tag automation:$(SANITIZED_TAG) --file automation/Dockerfile .
 
 docker-build-console-ui: ## Build console ui image
-	@echo "Build console ui docker image with tag $(TAG)"
-	docker build --no-cache --platform linux/amd64 --tag console_ui:$(TAG) --file console/ui/Dockerfile .
+	@echo "Build console ui docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
+	docker build --no-cache --platform linux/amd64 --tag console_ui:$(SANITIZED_TAG) --file console/ui/Dockerfile .
 
 docker-build-console-api: ## Build console api image
-	@echo "Build console api docker image with tag $(TAG)"
-	docker build --no-cache --platform linux/amd64 --tag console_api:$(TAG) --file console/service/Dockerfile .
+	@echo "Build console api docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
+	docker build --no-cache --platform linux/amd64 --tag console_api:$(SANITIZED_TAG) --file console/service/Dockerfile .
 
 docker-build-console-db: ## Build console db image
-	@echo "Build console db docker image with tag $(TAG)"
-	docker build --no-cache --platform linux/amd64 --tag console_db:$(TAG) --file console/db/Dockerfile .
+	@echo "Build console db docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
+	docker build --no-cache --platform linux/amd64 --tag console_db:$(SANITIZED_TAG) --file console/db/Dockerfile .
 
 docker-build-console: ## Build console image (all services)
-	@echo "Build console docker image with tag $(TAG)"
-	docker build --no-cache --platform linux/amd64 --tag console:$(TAG) --file console/Dockerfile .
+	@echo "Build console docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
+	docker build --no-cache --platform linux/amd64 --tag console:$(SANITIZED_TAG) --file console/Dockerfile .
 
 .PHONY: docker-push docker-push-console-ui docker-push-console-api docker-push-console-db docker-push-console
 docker-push: docker-push-automation docker-push-console-ui docker-push-console-api docker-push-console-db docker-push-console ## Push all images to Dockerhub (example: make docker-push TAG=my_tag DOCKER_REGISTRY=my_repo DOCKER_REGISTRY_USER="my_username" DOCKER_REGISTRY_PASSWORD="my_password")
 
 docker-push-automation: ## Push automation to Dockerhub
-	@echo "Push automation docker image with tag $(TAG)";
+	@echo "Push automation docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))";
 	echo "$(DOCKER_REGISTRY_PASSWORD)" | docker login --username "$(DOCKER_REGISTRY_USER)" --password-stdin
-	docker tag automation:$(TAG) $(DOCKER_REGISTRY)/automation:$(TAG)
-	docker push $(DOCKER_REGISTRY)/automation:$(TAG)
+	docker tag automation:$(SANITIZED_TAG) $(DOCKER_REGISTRY)/automation:$(SANITIZED_TAG)
+	docker push $(DOCKER_REGISTRY)/automation:$(SANITIZED_TAG)
 
 docker-push-console-ui: ## Push console ui image to Dockerhub
-	@echo "Push console ui docker image with tag $(TAG)"
+	@echo "Push console ui docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
 	echo "$(DOCKER_REGISTRY_PASSWORD)" | docker login --username "$(DOCKER_REGISTRY_USER)" --password-stdin
-	docker tag console_ui:$(TAG) $(DOCKER_REGISTRY)/console_ui:$(TAG)
-	docker push $(DOCKER_REGISTRY)/console_ui:$(TAG)
+	docker tag console_ui:$(SANITIZED_TAG) $(DOCKER_REGISTRY)/console_ui:$(SANITIZED_TAG)
+	docker push $(DOCKER_REGISTRY)/console_ui:$(SANITIZED_TAG)
 
 docker-push-console-api: ## Push console api image to Dockerhub
-	@echo "Push console api docker image with tag $(TAG)"
+	@echo "Push console api docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
 	echo "$(DOCKER_REGISTRY_PASSWORD)" | docker login --username "$(DOCKER_REGISTRY_USER)" --password-stdin
-	docker tag console_api:$(TAG) $(DOCKER_REGISTRY)/console_api:$(TAG)
-	docker push $(DOCKER_REGISTRY)/console_api:$(TAG)
+	docker tag console_api:$(SANITIZED_TAG) $(DOCKER_REGISTRY)/console_api:$(SANITIZED_TAG)
+	docker push $(DOCKER_REGISTRY)/console_api:$(SANITIZED_TAG)
 
 docker-push-console-db: ## Push console db image to Dockerhub
-	@echo "Push console db docker image with tag $(TAG)"
+	@echo "Push console db docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
 	echo "$(DOCKER_REGISTRY_PASSWORD)" | docker login --username "$(DOCKER_REGISTRY_USER)" --password-stdin
-	docker tag console_db:$(TAG) $(DOCKER_REGISTRY)/console_db:$(TAG)
-	docker push $(DOCKER_REGISTRY)/console_db:$(TAG)
+	docker tag console_db:$(SANITIZED_TAG) $(DOCKER_REGISTRY)/console_db:$(SANITIZED_TAG)
+	docker push $(DOCKER_REGISTRY)/console_db:$(SANITIZED_TAG)
 
 docker-push-console: ## Push console image to Dockerhub (all services)
-	@echo "Push console docker image with tag $(TAG)"
+	@echo "Push console docker image with tag $(TAG) (sanitized as $(SANITIZED_TAG))"
 	echo "$(DOCKER_REGISTRY_PASSWORD)" | docker login --username "$(DOCKER_REGISTRY_USER)" --password-stdin
-	docker tag console:$(TAG) $(DOCKER_REGISTRY)/console:$(TAG)
-	docker push $(DOCKER_REGISTRY)/console:$(TAG)
+	docker tag console:$(SANITIZED_TAG) $(DOCKER_REGISTRY)/console:$(SANITIZED_TAG)
+	docker push $(DOCKER_REGISTRY)/console:$(SANITIZED_TAG)
 
 .PHONY: docker-tests
 docker-tests: ## Run tests for docker

--- a/automation/roles/pgbackrest/tasks/ssh_keys.yml
+++ b/automation/roles/pgbackrest/tasks/ssh_keys.yml
@@ -79,7 +79,7 @@
     - pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y'
 
 - name: known_hosts | Get public ssh keys of hosts (ssh-keyscan)
-  ansible.builtin.command: "ssh-keyscan -trsa -p {{ ansible_ssh_port | default(22) }} {{ item }}"
+  ansible.builtin.command: "ssh-keyscan -trsa -p {{ hostvars[item].ansible_ssh_port | default(hostvars[item].ansible_port) | default(22) }} {{ item }}"
   loop: "{{ groups['all'] }}"
   register: ssh_known_host_keyscan
   changed_when: false
@@ -88,7 +88,7 @@
   become: true
   become_user: postgres
   ansible.builtin.known_hosts:
-    host: "{{ item.item }}"
+    name: "{{ item.stdout.split(' ')[0] }}"
     key: "{{ item.stdout }}"
     path: "~postgres/.ssh/known_hosts"
   no_log: true
@@ -99,7 +99,7 @@
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
   ansible.builtin.known_hosts:
-    host: "{{ item.item }}"
+    name: "{{ item.stdout.split(' ')[0] }}"
     key: "{{ item.stdout }}"
     path: "~{{ pgbackrest_repo_user }}/.ssh/known_hosts"
   no_log: true

--- a/automation/roles/pgbackrest/tasks/ssh_keys.yml
+++ b/automation/roles/pgbackrest/tasks/ssh_keys.yml
@@ -88,7 +88,7 @@
   become: true
   become_user: postgres
   ansible.builtin.known_hosts:
-    name: "{{ item.stdout.split(' ')[0] }}"
+    host: "{{ item.stdout.split(' ')[0] }}"
     key: "{{ item.stdout }}"
     path: "~postgres/.ssh/known_hosts"
   no_log: true
@@ -99,7 +99,7 @@
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
   ansible.builtin.known_hosts:
-    name: "{{ item.stdout.split(' ')[0] }}"
+    host: "{{ item.stdout.split(' ')[0] }}"
     key: "{{ item.stdout }}"
     path: "~{{ pgbackrest_repo_user }}/.ssh/known_hosts"
   no_log: true


### PR DESCRIPTION
If a custom ssh port is set for a host via `ansible_port`, the current logic for the `known_hosts` insert will fail.

These changes account for it by also checking for `ansible_port` and adjusting the final insert to work as intended.

Side note: in `inventory.example`, `ansible_ssh_port` is used. This is [considered legacy and `ansible_port` should be used instead](https://bugs.launchpad.net/openstack-ansible/+bug/1636606). 

Unrelated workflow fix: account for `/` in branch names, so tests don't fail (`/` are not allowed as docker tags)