### PR TITLE
Exclusion of redefinition of copy_files_to_all_server in GitOps

### DIFF
--- a/automation/pg_upgrade.yml
+++ b/automation/pg_upgrade.yml
@@ -127,8 +127,8 @@
     - name: Copy files
       ansible.builtin.include_role:
         name: copy
-      vars: 
-        copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
+      vars:
+        copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server }}"
 
     - name: Check Schema Compatibility
       ansible.builtin.import_role:

--- a/automation/pg_upgrade.yml
+++ b/automation/pg_upgrade.yml
@@ -127,7 +127,8 @@
     - name: Copy files
       ansible.builtin.include_role:
         name: copy
-      vars: copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
+      vars: 
+        copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
 
     - name: Check Schema Compatibility
       ansible.builtin.import_role:

--- a/automation/pg_upgrade.yml
+++ b/automation/pg_upgrade.yml
@@ -122,15 +122,12 @@
         name: upgrade
         tasks_from: initdb
 
-    - name:  Substitution of a variable copy_files_to_all_server
-      set_fact:
-        copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
-
     # (optional) copy files specified in variable:
     # 'copy_files_to_all_server'
     - name: Copy files
       ansible.builtin.include_role:
         name: copy
+      vars: copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
 
     - name: Check Schema Compatibility
       ansible.builtin.import_role:

--- a/automation/pg_upgrade.yml
+++ b/automation/pg_upgrade.yml
@@ -122,6 +122,10 @@
         name: upgrade
         tasks_from: initdb
 
+    - name:  Substitution of a variable copy_files_to_all_server
+      set_fact:
+        copy_files_to_all_server: "{{ upgrade_copy_files_to_all_server  }}"
+
     # (optional) copy files specified in variable:
     # 'copy_files_to_all_server'
     - name: Copy files

--- a/automation/roles/common/defaults/upgrade.yml
+++ b/automation/roles/common/defaults/upgrade.yml
@@ -75,7 +75,7 @@ max_transaction_sec: 15 # Maximum allowed duration for a transactions in seconds
 
 # (optional) Copy any files located in the "files" directory to all servers
 # example for Postgres Full-Text Search (FTS) files
-copy_files_to_all_server: []
+upgrade_copy_files_to_all_server: []
 #  - { src: "files/numbers.syn", dest: "/usr/share/postgresql/{{ pg_new_version }}/tsearch_data/numbers.syn", owner: "root", group: "root", mode: "0644" }
 #  - { src: "files/part_of_speech_russian.stop", dest: "/usr/share/postgresql/{{ pg_new_version }}/tsearch_data/part_of_speech_russian.stop", owner: "root", group: "root", mode: "0644" }
 #  - { src: "files/ru_ru.affix", dest: "/usr/share/postgresql/{{ pg_new_version }}/tsearch_data/ru_ru.affix", owner: "root", group: "root", mode: "0644" }


### PR DESCRIPTION
When a repository is used in the GitOps approach, custom files are transferred to extra-vars. 
In this case, the copy_files_to_all_server variable overrides itself between the system.yml and upgrade.yml files.
This PR renames copy_files_to_all_server in the upgrade.yml file, and then in the pg_upgrade playbook.yml overrides this variable.