### PR TITLE
feat: modify renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended", "group:recommended", "schedule:automergeDaily", "schedule:weekends", ":maintainLockFilesWeekly"],
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
These changes will

- open dependency PRs only on the weekend 
- allow possible automerge daily (turned off currently so this will not have an effect right now but it is good to have it as a default in case that changes at some point)
- only ever open 5 dep PRs at a time (to prevent hitting rate-limits for your GHA runs)
- add the "dependencies" label to all PRs
- group related dependencies in one PR (see the grouping logic [here](https://docs.renovatebot.com/presets-group/#grouprecommended))