### PR TITLE
Simplify the molecule test workflow

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,16 +19,7 @@ jobs:
           - distro: debian12
             tag: latest
             namespace: geerlingguy
-          - distro: debian11
-            tag: latest
-            namespace: geerlingguy
           - distro: ubuntu2404
-            tag: latest
-            namespace: geerlingguy
-          - distro: ubuntu2204
-            tag: latest
-            namespace: geerlingguy
-          - distro: rockylinux8
             tag: latest
             namespace: geerlingguy
           - distro: rockylinux9
@@ -38,9 +29,6 @@ jobs:
             tag: latest
             namespace: glillico
           - distro: almalinux9
-            tag: latest
-            namespace: glillico
-          - distro: oraclelinux8
             tag: latest
             namespace: glillico
           - distro: oraclelinux9


### PR DESCRIPTION
Simplify Molecule CI by testing only latest distro versions.

This PR updates the molecule.yml workflow to test only the latest supported versions of major Linux distributions.
Older versions (e.g., Debian 11, Ubuntu 20.04, RockyLinux 8) are excluded from the CI matrix to reduce execution time and resource usage.

Note: Older distributions will still be tested daily via the scheduled CI workflow.