### PR TITLE
feat: add generic s3 backup options

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -499,6 +499,9 @@ patroni_create_replica_methods:
   #  - pg_probackup
   - basebackup
 
+# if set, will configure s3 backups to the respective provider. Possible values: aws_s3, azure_s3, digitalocean_s3, hetzner_s3, gcp_s3
+backup_provider: ""
+
 pgbackrest:
   - { option: "command", value: "{{ pgbackrest_patroni_cluster_restore_command }}" }
   - { option: "keep_data", value: "True" }

--- a/automation/roles/pgbackrest/tasks/auto_conf.yml
+++ b/automation/roles/pgbackrest/tasks/auto_conf.yml
@@ -38,7 +38,7 @@
   delegate_to: localhost
   run_once: true # noqa run-once
   no_log: true # do not output contents to the ansible log
-  when: cloud_provider | default('') | lower == 'aws'
+  when: cloud_provider | default('') | lower == 'aws' or backup_provider == 'aws_s3'
 
 # GCS Bucket (if 'cloud_provider=gcp')
 - block:
@@ -101,7 +101,7 @@
         group: "postgres"
       no_log: true # do not output GCP service account contents to the ansible log
       when: gcs_key_file is defined and gcs_key_file | length > 0
-  when: cloud_provider | default('') | lower == 'gcp'
+  when: cloud_provider | default('') | lower == 'gcp' or backup_provider == 'gcp_s3'
 
 # Azure Blob Storage (if 'cloud_provider=azure')
 - name: "Set variable 'pgbackrest_conf' for backup in Azure Blob Storage"
@@ -141,7 +141,7 @@
         - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   no_log: true # do not output contents to the ansible log
-  when: cloud_provider | default('') | lower == 'azure'
+  when: cloud_provider | default('') | lower == 'azure' or backup_provider == 'azure_s3'
 
 # DigitalOcean Spaces Object Storage (if 'cloud_provider=digitalocean')
 # Note: requires the Spaces access keys "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" (https://cloud.digitalocean.com/account/api/spaces)
@@ -181,7 +181,7 @@
         - { option: "recovery-option", value: "recovery_target_action=promote" }
         - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
   no_log: true # do not output contents to the ansible log
-  when: cloud_provider | default('') | lower == 'digitalocean'
+  when: cloud_provider | default('') | lower == 'digitalocean' or backup_provider == 'digitalocean_s3'
 
 # Hetzner Object Storage (if 'cloud_provider=hetzner')
 - name: "Set variable 'pgbackrest_conf' for backup in Hetzner Object Storage (S3 bucket)"
@@ -222,4 +222,4 @@
   delegate_to: localhost
   run_once: true # noqa run-once
   no_log: true # do not output contents to the ansible log
-  when: cloud_provider | default('') | lower == 'hetzner'
+  when: cloud_provider | default('') | lower == 'hetzner' or backup_provider == 'hetzner_s3'

--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -3,7 +3,7 @@
 # if 'cloud_provider' is 'aws', 'gcp', 'azure', 'digitalocean'.
 - ansible.builtin.import_tasks: auto_conf.yml
   when:
-    - cloud_provider | default('') | length > 0
+    - cloud_provider | default('') | length > 0 or backup_provider != ''
     - pgbackrest_auto_conf | default(true) | bool # to be able to disable auto backup settings
   tags: pgbackrest, pgbackrest_conf
 


### PR DESCRIPTION
So far this was only able when using `cloud-provider`. Now, one can set `backup_provider` to one of the mentioned options and backup to S3 through `pgbackrest` when the `autobase` cluster has been deployed via Ansible.

Feel free to tweak to your liking, I just had this already in use since some time and wanted to part the idea upstream.

In addition to setting `backup_provider`, this also requires setting the respective access keys, storage name and other vars required to configure the S3 backend.