### PR TITLE
Fix data directory cleanup condition

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -520,8 +520,7 @@
             - absent
             - directory
           when: postgresql_wal_dir | default('') | length > 0
-      when: (inventory_hostname == groups['master'][0] and patroni_cluster_bootstrap_method != "pgbackrest")
-        or (inventory_hostname in groups['replica'] and ('pgbackrest' not in patroni_create_replica_methods or new_node | default(false) | bool))
+      when: patroni_cluster_bootstrap_method != "pgbackrest"
   when: not postgresql_exists | default(false) | bool or patroni_cluster_bootstrap_method != "initdb"
   tags: patroni, point_in_time_recovery
 


### PR DESCRIPTION
This PR corrects the logic that determines when to clean the PostgreSQL data directory during cluster deployment. 

Previously, the cleanup task was unintentionally skipped on replicas due to an overly strict condition. The logic is now simplified to ensure the directory is always cleared unless pgbackrest is used for bootstrapping.

Fixed:

```
16:10:26 [null@localhost 1][NORMAL] TASK [patroni : Prepare PostgreSQL | generate default PostgreSQL config files] ***
16:10:26 [null@localhost 1][NORMAL] changed: [172.**.**.22]
16:10:26 [null@localhost 1][NORMAL] changed: [172.**.**.21]
16:10:26 [null@localhost 1][NORMAL] 
16:10:26 [null@localhost 1][NORMAL] TASK [patroni : Prepare PostgreSQL | make sure the data directory "/var/lib/postgresql/16/main" is empty] ***
16:10:26 [null@localhost 1][NORMAL] changed: [172.**.**.21] => (item=absent)
16:10:26 [null@localhost 1][NORMAL] changed: [172.**.**.21] => (item=directory)
16:10:28 [null@localhost 1][NORMAL] 
16:10:28 [null@localhost 1][NORMAL] TASK [patroni : Start patroni service on the Master server] ********************
16:10:28 [null@localhost 1][NORMAL] changed: [172.**.**.21]
16:10:38 [null@localhost 1][NORMAL] 
16:10:38 [null@localhost 1][NORMAL] TASK [patroni : Wait for port 8008 to become open on the host] *****************
16:10:38 [null@localhost 1][NORMAL] ok: [172.**.**.21]
16:10:39 [null@localhost 1][NORMAL] FAILED - RETRYING: [172.**.**.21]: Wait for the Standby cluster initialization to complete (2880 retries left).
16:11:09 [null@localhost 1][NORMAL] FAILED - RETRYING: [172.**.**.21]: Wait for the Standby cluster initialization to complete (2879 retries left).
16:11:39 [null@localhost 1][NORMAL] FAILED - RETRYING: [172.**.**.21]: Wait for the Standby cluster initialization to complete (2878 retries left).
...
17:23:15 [null@localhost 1][NORMAL] FAILED - RETRYING: [172.**.**.21]: Wait for the Standby cluster initialization to complete (2736 retries left).
17:23:45 [null@localhost 1][NORMAL] 
17:23:45 [null@localhost 1][NORMAL] TASK [patroni : Wait for the Standby cluster initialization to complete] *******
17:23:45 [null@localhost 1][NORMAL] ok: [172.**.**.21]
17:23:45 [null@localhost 1][NORMAL] 
17:23:45 [null@localhost 1][NORMAL] TASK [patroni : Check PostgreSQL is started and accepting connections] *********
17:23:45 [null@localhost 1][NORMAL] ok: [172.**.**.21]
17:23:46 [null@localhost 1][NORMAL] 
17:23:46 [null@localhost 1][NORMAL] TASK [patroni : Prepare PostgreSQL | generate pg_hba.conf] *********************
17:23:46 [null@localhost 1][NORMAL] changed: [172.**.**.21]
17:23:46 [null@localhost 1][NORMAL] changed: [172.**.**.22]
17:23:47 [null@localhost 1][NORMAL] 
17:23:47 [null@localhost 1][NORMAL] TASK [patroni : Prepare PostgreSQL | reload for apply the pg_hba.conf] *********
17:23:47 [null@localhost 1][NORMAL] changed: [172.**.**.21]
17:23:47 [null@localhost 1][NORMAL] ok: [172.**.**.22]
17:23:47 [null@localhost 1][NORMAL] 
17:23:47 [null@localhost 1][NORMAL] TASK [patroni : Start patroni service on Replica servers] **********************
17:23:47 [null@localhost 1][NORMAL] changed: [172.**.**.22]
17:25:48 [null@localhost 1][NORMAL] 
17:25:48 [null@localhost 1][NORMAL] TASK [patroni : Wait for port 8008 to become open on the host] *****************
17:25:48 [null@localhost 1][NORMAL] fatal: [172.**.**.22]: FAILED! => {"changed": false, "elapsed": 120, "msg": "Timeout when waiting for 172.**.**.22:8008"}
17:25:48 [null@localhost 1][NORMAL] 
```
Note: The directory was not cleared on replica because pgbackrest was defined in the patroni_create_replica_methods variable.