### PR TITLE
Add support for target_roles in the postgresql_privs task

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -241,6 +241,7 @@ postgresql_privs: []
 #  - { role: "user", privs: "EXECUTE", type: "function", db: "db1", objs: "pg_ls_waldir()", schema: "pg_catalog" }  # grant EXECUTE on a function
 #  - { role: "user, privs: "SELECT", type: "table", db: "mydb", objs: "table2", schema: "schema2", state: "absent" }  # revoke SELECT on a table2 and schema2
 #  - { role: "test, test2", privs: "CREATE", type: "database", db: "test2", objs: "test2" }  # grant CREATE on a database test2 to role test and test2
+#  - { role: "invnatom_ms", privs: "EXECUTE", type: "default_privs", db: "invnatom_db_prod", schema: "invnatom", objs: "FUNCTIONS", target_roles: "invnatom_cd" }  # grant EXECUTE on future functions in schema invnatom to role invnatom_cd
 
 # (optional) list of database extensions to be created (if not already exists)
 postgresql_extensions: []

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -241,7 +241,7 @@ postgresql_privs: []
 #  - { role: "user", privs: "EXECUTE", type: "function", db: "db1", objs: "pg_ls_waldir()", schema: "pg_catalog" }  # grant EXECUTE on a function
 #  - { role: "user, privs: "SELECT", type: "table", db: "mydb", objs: "table2", schema: "schema2", state: "absent" }  # revoke SELECT on a table2 and schema2
 #  - { role: "test, test2", privs: "CREATE", type: "database", db: "test2", objs: "test2" }  # grant CREATE on a database test2 to role test and test2
-#  - { role: "invnatom_ms", privs: "EXECUTE", type: "default_privs", db: "invnatom_db_prod", schema: "invnatom", objs: "FUNCTIONS", target_roles: "invnatom_cd" }  # grant EXECUTE on future functions in schema invnatom to role invnatom_cd
+#  - { role: "invnatom_ms", privs: "EXECUTE", type: "default_privs", db: "invnatom_db", schema: "invnatom", objs: "FUNCTIONS", target_roles: "invnatom_cd" }
 
 # (optional) list of database extensions to be created (if not already exists)
 postgresql_extensions: []

--- a/automation/roles/postgresql_privs/tasks/main.yml
+++ b/automation/roles/postgresql_privs/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Grant/revoke privileges on objects
   community.postgresql.postgresql_privs:
     roles: "{{ item.role }}"
+    target_roles: "{{ item.target_roles if item.type == 'default_privs' and item.target_roles | default('') | length > 0 else omit }}"
     privs: "{{ item.privs }}"
     type: "{{ item.type }}"
     objs: "{{ item.objs }}"


### PR DESCRIPTION
This change enables specifying [target_roles](https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_privs_module.html#parameter-target_roles) in `postgresql_privs` variable.