### PR TITLE
Extension Auto-Setup: Looking up the latest available package

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
           TAG: ${{ env.TAG }}
 
       - name: Run Docker push
-        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' }}
+        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
         run: make docker-push
         env:
           TAG: ${{ env.TAG }}

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -71,6 +71,7 @@
         enable_pg_partman: true
         enable_citus: "{{ 'false' if ansible_distribution_release == 'noble' else 'true' }}" # no packages for Ubuntu 24.04 (TODO)
         enable_pg_analytics: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}" # no packages for debian 11
+        enable_pg_search: true
         pg_search_version: "0.15.18" # rpm packages of v0.15.19 are broken.
         enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
         # create extension

--- a/automation/molecule/pg_upgrade/converge.yml
+++ b/automation/molecule/pg_upgrade/converge.yml
@@ -23,6 +23,34 @@
       delegate_to: localhost
       run_once: true # noqa run-once
 
+    # Extension Auto-Setup
+    - name: Set variables for Extensions test
+      ansible.builtin.set_fact:
+        enable_timescale: true
+        enable_pg_repack: true
+        enable_pg_cron: true
+        enable_pgaudit: true
+        enable_pgvector: true
+        enable_postgis: true
+        enable_pgrouting: true
+        enable_pg_stat_kcache: true
+        enable_pg_wait_sampling: true
+        enable_pg_partman: true
+        enable_pg_search: true
+        pg_search_version: "0.15.18" # rpm packages of v0.15.19 are broken.
+        enable_citus: "{{ 'false' if ansible_distribution_release == 'noble' else 'true' }}" # no packages for Ubuntu 24.04 (TODO)
+        enable_pg_analytics: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}" # no packages for debian 11
+        enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
+        # create extension
+        postgresql_schemas:
+          - { schema: "paradedb", db: "postgres", owner: "postgres" } # pg_search must be installed in the paradedb schema.
+        postgresql_extensions:
+          - { ext: "vector", db: "postgres" }
+          - { ext: "vectorscale", db: "postgres" }
+          - { ext: "pg_search", db: "postgres", schema: "paradedb" }
+          - { ext: "pg_analytics", db: "postgres" }
+        #  - { ext: "", db: "" }
+
     # Consul package for OracleLinux missing in HashiCorp repository
     # Only the installation of a binary file is supported
     - name: "Set variables: 'consul_install_from_repo: false' and 'patroni_installation_method: pip'"
@@ -37,10 +65,6 @@
       ansible.builtin.set_fact:
         postgresql_data_dir: "/pgdata/{{ postgresql_version }}/main"
         postgresql_wal_dir: "/pgwal/{{ postgresql_version }}/pg_wal"
-
-    - name: Set variables for TimescaleDB cluster deployment test
-      ansible.builtin.set_fact:
-        enable_timescale: true
 
     - name: Set variables for PostgreSQL upgrade test
       ansible.builtin.set_fact:

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1010,7 +1010,6 @@ yum_repository: []
 
 install_postgresql_repo: true # or 'false' (installed from the package "pgdg-redhat-repo-latest.noarch.rpm")
 install_epel_repo: true # or 'false' (installed from the package "epel-release-latest.noarch.rpm")
-install_scl_repo: true # or 'false' (Redhat 7 family only)
 
 postgresql_os_specific_packages:
   Debian:

--- a/automation/roles/packages/defaults/main.yml
+++ b/automation/roles/packages/defaults/main.yml
@@ -3,22 +3,3 @@ pgdg_architecture_map:
   amd64: x86_64
   x86_64: x86_64
   aarch64: aarch64
-
-# Extension Auto-Setup:
-pgvectorscale_architecture_map:
-  x86_64: amd64
-  amd64: amd64
-  aarch64: arm64
-  arm64: arm64
-
-paradedb_architecture_map_dep:
-  x86_64: amd64
-  amd64: amd64
-  aarch64: arm64
-  arm64: arm64
-
-paradedb_architecture_map_rpm:
-  x86_64: x86_64
-  amd64: x86_64
-  aarch64: aarch64
-  arm64: aarch64

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -302,12 +302,11 @@
     # Build regex to match the package by optional version, PG version, OS, arch
     search_pattern: >-
       {{
-        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '')
-        ~ (
-          ansible_os_family == 'RedHat'
-          | ternary(
-              'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-              'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '') ~
+        (
+          (ansible_os_family == 'RedHat') | ternary(
+            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
           )
         )
       }}

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -248,44 +248,28 @@
 # pgvectorscale - https://github.com/timescale/pgvectorscale
 # (if 'enable_pgvectorscale' is 'true')
 - block:
-    - name: Looking up the latest version of pgvectorscale
-      ansible.builtin.set_fact:
-        pgvectorscale_version: >-
+    - name: Install pgvectorscale from GitHub
+      ansible.builtin.include_tasks: extensions_github.yml
+      vars:
+        github_repo: timescale/pgvectorscale
+        extension_name: pgvectorscale
+        extension_version: "{{ pgvectorscale_version | default('') }}"
+        # Build regex to match the package by optional version, PG version, OS, arch
+        search_pattern: >-
           {{
-            (lookup('url', 'https://api.github.com/repos/timescale/pgvectorscale/releases/latest', split_lines=False)
-            | from_json).get('tag_name')
-            | replace('v', '')
+            '.*'
+            ~ (pgvectorscale_version ~ '/' if pgvectorscale_version is defined else '')
+            ~ 'pgvectorscale-.*-pg' ~ (pg_version | default(postgresql_version))
+            ~ '-' ~ pgvectorscale_architecture_map[ansible_architecture]
+            ~ '\.zip$'
           }}
-      check_mode: false
-      when: pgvectorscale_version | default('latest') == 'latest'
-
-    - name: Download pgvectorscale archive
-      ansible.builtin.get_url:
-        url: "{{ pgvectorscale_repo }}/{{ pgvectorscale_archive }}"
-        dest: "/tmp/{{ pgvectorscale_archive }}"
-        timeout: 60
-        validate_certs: false
-      check_mode: false
-
-    - name: Extract pgvectorscale package
-      ansible.builtin.unarchive:
-        src: "/tmp/{{ pgvectorscale_archive }}"
-        dest: "/tmp/"
-        remote_src: true
-      check_mode: false
-
-    # Debian (only deb packages are available)
-    - name: "Install pgvectorscale v{{ pgvectorscale_version }} package"
-      ansible.builtin.apt:
-        deb: "/tmp/{{ pgvectorscale_package }}"
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-  vars:
-    pgvectorscale_repo: "https://github.com/timescale/pgvectorscale/releases/download/{{ pgvectorscale_version }}"
-    pgvectorscale_archive: "pgvectorscale-{{ pgvectorscale_version }}-pg{{ pg_version | default(postgresql_version) }}-{{ pgvectorscale_architecture_map[ansible_architecture] }}.zip" # yamllint disable rule:line-length
-    pgvectorscale_package: "pgvectorscale-postgresql-{{ pg_version | default(postgresql_version) }}_{{ pgvectorscale_version }}-Linux_{{ pgvectorscale_architecture_map[ansible_architecture] }}.deb" # yamllint disable rule:line-length
+        # Defining the expected package name pattern to match inside the archive
+        package_name_pattern: >-
+          {{
+            'pgvectorscale-postgresql-'
+            ~ (pg_version | default(postgresql_version)) ~ '.*'
+            ~ pgvectorscale_architecture_map[ansible_architecture] ~ '\.deb$'
+          }}
   when:
     - enable_pgvectorscale | default(false) | bool
     - ansible_os_family == "Debian"
@@ -298,7 +282,7 @@
   vars:
     github_repo: paradedb/paradedb
     extension_name: pg_search
-    extension_version: "{{ pg_search_version | default(omit) }}"
+    extension_version: "{{ pg_search_version | default('') }}"
     # Build regex to match the package by optional version, PG version, OS, arch
     search_pattern: >-
       {{

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -298,15 +298,15 @@
         pg_search_package_url: "{{ match.browser_download_url }}"
         pg_search_version: "{{ match.release_tag }}"
       vars:
-        pg_version: "{{ pg_version | default(postgresql_version) }}"
+        postgres_version: "{{ pg_version | default(postgresql_version) }}"
         releases: >-
           {{ lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases?per_page=10', split_lines=False) | from_json }}
         pattern: >-
           {{
             (ansible_os_family == 'RedHat')
             | ternary(
-                'pg_search_' ~ pg_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
-                'postgresql-' ~ pg_version ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+                'pg_search_' ~ postgres_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
+                'postgresql-' ~ postgres_version ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
             )
           }}
         match: >-
@@ -353,15 +353,15 @@
         pg_analytics_package_url: "{{ match.browser_download_url }}"
         pg_analytics_version: "{{ match.release_tag }}"
       vars:
-        pg_version: "{{ pg_version | default(postgresql_version) }}"
+        postgres_version: "{{ pg_version | default(postgresql_version) }}"
         releases: >-
           {{ lookup('url', 'https://api.github.com/repos/paradedb/pg_analytics/releases?per_page=10', split_lines=False) | from_json }}
         pattern: >-
           {{
             (ansible_os_family == 'RedHat')
             | ternary(
-                'pg_analytics_' ~ pg_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
-                'postgresql-' ~ pg_version ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+                'pg_analytics_' ~ postgres_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
+                'postgresql-' ~ postgres_version ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
             )
           }}
         match: >-

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -270,6 +270,12 @@
             ~ (pg_version | default(postgresql_version)) ~ '.*'
             ~ pgvectorscale_architecture_map[ansible_architecture] ~ '\.deb$'
           }}
+  vars:
+    pgvectorscale_architecture_map:
+      x86_64: amd64
+      amd64: amd64
+      aarch64: arm64
+      arm64: arm64
   when:
     - enable_pgvectorscale | default(false) | bool
     - ansible_os_family == "Debian"
@@ -289,11 +295,21 @@
         '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '') ~
         (
           (ansible_os_family == 'RedHat') | ternary(
-            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (pg_search_architecture_map_dep[ansible_architecture]) ~ '\.rpm$',
+            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (pg_search_architecture_map_rpm[ansible_architecture]) ~ '\.deb$'
           )
         )
       }}
+    pg_search_architecture_map_dep:
+      x86_64: amd64
+      amd64: amd64
+      aarch64: arm64
+      arm64: arm64
+    pg_search_architecture_map_rpm:
+      x86_64: x86_64
+      amd64: x86_64
+      aarch64: aarch64
+      arm64: aarch64
   when: enable_paradedb | default(false) | bool or enable_pg_search | default(false) | bool
   tags: paradedb, pg_search
 
@@ -302,7 +318,7 @@
 - block:
     - name: "Install pg_analytics v{{ version }} package"
       ansible.builtin.apt:
-        deb: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ paradedb_architecture_map_dep[ansible_architecture] }}.deb"
+        deb: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ pg_analytics_architecture_map_dep[ansible_architecture] }}.deb"
       register: apt_status
       until: apt_status is success
       delay: 5
@@ -313,7 +329,7 @@
 
     - name: "Install pg_analytics v{{ version }} package"
       ansible.builtin.dnf:
-        name: "{{ pg_analytics_repo }}/pg_analytics_{{ pg_version | default(postgresql_version) }}-{{ version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ paradedb_architecture_map_rpm[ansible_architecture] }}.rpm"
+        name: "{{ pg_analytics_repo }}/pg_analytics_{{ pg_version | default(postgresql_version) }}-{{ version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ pg_analytics_architecture_map_rpm[ansible_architecture] }}.rpm"
         disable_gpg_check: true
       register: dnf_status
       until: dnf_status is success
@@ -325,5 +341,15 @@
   vars:
     version: "{{ pg_analytics_version | default('0.3.7') }}"
     pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ version }}/"
+    pg_analytics_architecture_map_dep:
+      x86_64: amd64
+      amd64: amd64
+      aarch64: arm64
+      arm64: arm64
+    pg_analytics_architecture_map_rpm:
+      x86_64: x86_64
+      amd64: x86_64
+      aarch64: aarch64
+      arm64: aarch64
   when: enable_paradedb | default(false) | bool or enable_pg_analytics | default(false) | bool
   tags: paradedb, pg_analytics

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -361,8 +361,6 @@
       until: apt_status is success
       delay: 5
       retries: 3
-      vars:
-        pg_analytics_package: 
       when:
         - ansible_os_family == "Debian"
         - ansible_distribution_release in ['bookworm', 'jammy', 'noble']

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -325,6 +325,14 @@
           }}
       check_mode: false
 
+    # If not found, show the error and continue the playbook execution
+    - name: pg_search package not found
+      ansible.builtin.fail:
+        msg: "ERROR: No matching pg_search package found for this system."
+      ignore_errors: true
+      when: pg_search_package_url | length == 0
+
+    # If found, download and install
     - name: "Download pg_search package ({{ pg_search_package_url | basename }})"
       ansible.builtin.get_url:
         url: "{{ pg_search_package_url }}"
@@ -336,6 +344,7 @@
       retries: 3
       delay: 5
       check_mode: false
+      when: pg_search_package_url | length > 0
 
     - name: Install pg_search package
       ansible.builtin.apt:
@@ -344,7 +353,7 @@
       until: apt_status is succeeded
       retries: 3
       delay: 5
-      when: ansible_os_family == 'Debian'
+      when: ansible_os_family == 'Debian' and pg_search_package_url | length > 0
 
     - name: Install pg_search package
       ansible.builtin.dnf:
@@ -354,7 +363,7 @@
       until: dnf_status is succeeded
       retries: 3
       delay: 5
-      when: ansible_os_family == 'RedHat'
+      when: ansible_os_family == 'RedHat' and pg_search_package_url | length > 0
   when: enable_paradedb | default(false) | bool or enable_pg_search | default(false) | bool
   tags: paradedb, pg_search
 

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -293,77 +293,24 @@
 
 # ParadeDB - https://github.com/paradedb/paradedb
 # pg_search (if 'enable_paradedb' or 'enable_pg_search' is 'true')
-- block:
-    - name: "Looking up {{ pg_search_version | default('latest available') }} pg_search package"
-      ansible.builtin.set_fact:
-        # Set the download URL for the matched package (if found)
-        pg_search_package_url: "{{ match_asset.browser_download_url | default('') }}"
-      vars:
-        # Fetch and parse the latest 10 release entries from the GitHub API
-        releases: >-
-          {{ lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases?per_page=10', split_lines=False) | from_json }}
-        # Build regex to match the package by optional version, PG version, OS, arch
-        search_pattern: >-
-          {{
-            '.*'
-            ~ (pg_search_version | default('') ~ '/')
-            ~ (
-              ansible_os_family == 'RedHat'
-              | ternary(
-                  'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-                  'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
-              )
-            )
-          }}
-        # From all available release assets, find the first one matching our pattern
-        match_asset: >-
-          {{
-            releases
-            | map(attribute='assets') | map('default', []) | flatten
-            | selectattr('browser_download_url', 'match', search_pattern)
-            | list | first | default({})
-          }}
-      check_mode: false
-
-    # If not found, show the error and continue the playbook execution
-    - name: pg_search package not found
-      ansible.builtin.fail:
-        msg: "ERROR: No matching pg_search package found for this system."
-      ignore_errors: true
-      when: pg_search_package_url | length == 0
-
-    # If found, download and install
-    - name: "Download pg_search package ({{ pg_search_package_url | basename }})"
-      ansible.builtin.get_url:
-        url: "{{ pg_search_package_url }}"
-        dest: "/tmp/{{ pg_search_package_url | basename }}"
-        timeout: 60
-        validate_certs: false
-      register: get_url_status
-      until: get_url_status is succeeded
-      retries: 3
-      delay: 5
-      check_mode: false
-      when: pg_search_package_url | length > 0
-
-    - name: Install pg_search package
-      ansible.builtin.apt:
-        deb: "/tmp/{{ pg_search_package_url | basename }}"
-      register: apt_status
-      until: apt_status is succeeded
-      retries: 3
-      delay: 5
-      when: ansible_os_family == 'Debian' and pg_search_package_url | length > 0
-
-    - name: Install pg_search package
-      ansible.builtin.dnf:
-        name: "/tmp/{{ pg_search_package_url | basename }}"
-        state: present
-      register: dnf_status
-      until: dnf_status is succeeded
-      retries: 3
-      delay: 5
-      when: ansible_os_family == 'RedHat' and pg_search_package_url | length > 0
+- name: Install pg_search from GitHub
+  ansible.builtin.include_tasks: extensions_github.yml
+  vars:
+    github_repo: paradedb/paradedb
+    extension_name: pg_search
+    extension_version: "{{ pg_search_version | default(omit) }}"
+    # Build regex to match the package by optional version, PG version, OS, arch
+    search_pattern: >-
+      {{
+        '.*' ~ (pg_search_version | default('') ~ '/')
+        ~ (
+          ansible_os_family == 'RedHat'
+          | ternary(
+              'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+              'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+          )
+        )
+      }}
   when: enable_paradedb | default(false) | bool or enable_pg_search | default(false) | bool
   tags: paradedb, pg_search
 

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -365,7 +365,7 @@
         - ansible_os_family == "Debian"
         - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
 
-    - name: "Install pg_analytics v{{ version) }} package"
+    - name: "Install pg_analytics v{{ version }} package"
       ansible.builtin.dnf:
         name: "{{ pg_analytics_repo }}/pg_analytics_{{ pg_version | default(postgresql_version) }}-{{ version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ paradedb_architecture_map_rpm[ansible_architecture] }}.rpm"
         disable_gpg_check: true

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -302,7 +302,7 @@
     # Build regex to match the package by optional version, PG version, OS, arch
     search_pattern: >-
       {{
-        '.*' ~ (pg_search_version | default('') ~ '/')
+        '.*' ~ (extension_version | default('') ~ '/')
         ~ (
           ansible_os_family == 'RedHat'
           | ternary(

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -295,43 +295,29 @@
 - block:
     - name: Looking up the latest available pg_search package
       ansible.builtin.set_fact:
-        pg_search_package_url: "{{ match.browser_download_url }}"
-        pg_search_version: "{{ match.release_tag }}"
+        pg_search_package_url: "{{ match_asset.browser_download_url | default('') }}"
       vars:
-        postgres_version: "{{ pg_version | default(postgresql_version) }}"
         releases: >-
           {{ lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases?per_page=10', split_lines=False) | from_json }}
-        pattern: >-
+        search_pattern: >-
           {{
             (ansible_os_family == 'RedHat')
             | ternary(
-                'pg_search_' ~ postgres_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
-                'postgresql-' ~ postgres_version ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+                'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+                'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
             )
           }}
-        match: >-
+        match_asset: >-
           {{
             releases
-            | selectattr('assets', 'defined')
-            | map('combine', {
-                'matched_asset': (
-                  attribute('assets')
-                  | selectattr('name', 'search', pattern)
-                  | list
-                  | first
-                )
-              })
-            | selectattr('matched_asset', 'defined')
-            | map('combine', {
-                'browser_download_url': attribute('matched_asset', 'browser_download_url'),
-                'release_tag': attribute('tag_name') | replace('v', '')
-              })
-            | list
-            | first
+            | map(attribute='assets') | map('default', []) | flatten
+            | selectattr('name', 'match', search_pattern)
+            | list | first | default({})
           }}
+      check_mode: false
       when: pg_search_version | default('latest') == 'latest'
 
-    - name: Download pg_search {{ pg_search_version }} package
+    - name: "Download pg_search package ({{ pg_search_package_url | basename }})"
       ansible.builtin.get_url:
         url: "{{ pg_search_package_url }}"
         dest: "/tmp/{{ pg_search_package_url | basename }}"
@@ -341,15 +327,26 @@
       until: get_url_status is succeeded
       retries: 3
       delay: 5
+      check_mode: false
 
-    - name: Install pg_search {{ pg_search_version }} package
-      ansible.builtin.package:
-        name: "/tmp/{{ pg_search_package_url | basename }}"
-        state: present
-      register: package_status
-      until: package_status is succeeded
+    - name: Install pg_search package
+      ansible.builtin.apt:
+        deb: "/tmp/{{ pg_search_package_url | basename }}"
+      register: apt_status
+      until: apt_status is succeeded
       retries: 3
       delay: 5
+      when: ansible_os_family == 'Debian'
+
+    - name: "Install pg_search {{ version }} package"
+      ansible.builtin.dnf:
+        name: "/tmp/{{ pg_search_package_url | basename }}"
+        state: present
+      register: dnf_status
+      until: dnf_status is succeeded
+      retries: 3
+      delay: 5
+      when: ansible_os_family == 'RedHat'
   when: enable_paradedb | default(false) | bool or pg_search | default(false) | bool
   tags: paradedb, pg_search
 
@@ -357,42 +354,29 @@
 - block:
     - name: Looking up the latest available pg_analytics package
       ansible.builtin.set_fact:
-        pg_analytics_package_url: "{{ match.browser_download_url }}"
-        pg_analytics_version: "{{ match.release_tag }}"
+        pg_analytics_package_url: "{{ match_asset.browser_download_url | default(omit) }}"
       vars:
-        postgres_version: "{{ pg_version | default(postgresql_version) }}"
         releases: >-
           {{ lookup('url', 'https://api.github.com/repos/paradedb/pg_analytics/releases?per_page=10', split_lines=False) | from_json }}
-        pattern: >-
+        search_pattern: >-
           {{
             (ansible_os_family == 'RedHat')
             | ternary(
-                'pg_analytics_' ~ postgres_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
-                'postgresql-' ~ postgres_version ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+                'pg_analytics_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+                'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
             )
           }}
-        match: >-
+        match_asset: >-
           {{
             releases
-            | selectattr('assets', 'defined')
-            | map('combine', {
-                'matched_asset': (
-                  attribute('assets')
-                  | selectattr('name', 'search', pattern)
-                  | list
-                  | first
-                )
-              })
-            | selectattr('matched_asset', 'defined')
-            | map('combine', {
-                'browser_download_url': attribute('matched_asset', 'browser_download_url'),
-                'release_tag': attribute('tag_name') | replace('v', '')
-              })
-            | list
-            | first
+            | map(attribute='assets') | map('default', []) | flatten
+            | selectattr('name', 'match', search_pattern)
+            | list | first | default({})
           }}
+      check_mode: false
+      when: pg_analytics_version | default('latest') == 'latest'
 
-    - name: Download pg_analytics {{ pg_analytics_version }} package
+    - name: "Download pg_analytics package ({{ pg_analytics_package_url | basename }})"
       ansible.builtin.get_url:
         url: "{{ pg_analytics_package_url }}"
         dest: "/tmp/{{ pg_analytics_package_url | basename }}"
@@ -402,14 +386,25 @@
       until: get_url_status is succeeded
       retries: 3
       delay: 5
+      check_mode: false
 
-    - name: Install pg_analytics {{ pg_analytics_version }} package
-      ansible.builtin.package:
-        name: "/tmp/{{ pg_analytics_package_url | basename }}"
-        state: present
-      register: package_status
-      until: package_status is succeeded
+    - name: Install pg_analytics package
+      ansible.builtin.apt:
+        deb: "/tmp/{{ pg_analytics_package_url | basename }}"
+      register: apt_status
+      until: apt_status is succeeded
       retries: 3
       delay: 5
+      when: ansible_os_family == 'Debian'
+
+    - name: Install pg_analytics package
+      ansible.builtin.dnf:
+        name: "/tmp/{{ pg_analytics_package_url | basename }}"
+        state: present
+      register: dnf_status
+      until: dnf_status is succeeded
+      retries: 3
+      delay: 5
+      when: ansible_os_family == 'RedHat'
   when: enable_paradedb | default(false) | bool or pg_analytics | default(false) | bool
   tags: paradedb, pg_analytics

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -348,7 +348,7 @@
       retries: 3
       delay: 5
       when: ansible_os_family == 'RedHat'
-  when: enable_paradedb | default(false) | bool or pg_search | default(false) | bool
+  when: enable_paradedb | default(false) | bool or enable_pg_search | default(false) | bool
   tags: paradedb, pg_search
 
 # pg_analytics (if 'enable_paradedb' or 'enable_pg_analytics' is 'true')
@@ -379,5 +379,5 @@
   vars:
     version: "{{ pg_analytics_version | default('0.3.7') }}"
     pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ version }}/"
-  when: enable_paradedb | default(false) | bool or pg_analytics | default(false) | bool
+  when: enable_paradedb | default(false) | bool or enable_pg_analytics | default(false) | bool
   tags: paradedb, pg_analytics

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -351,60 +351,34 @@
   tags: paradedb, pg_search
 
 # pg_analytics (if 'enable_paradedb' or 'enable_pg_analytics' is 'true')
+# Note: This repository was archived by the owner on Mar 20, 2025. Latest release: v0.3.7
 - block:
-    - name: Looking up the latest available pg_analytics package
-      ansible.builtin.set_fact:
-        pg_analytics_package_url: "{{ match_asset.browser_download_url | default(omit) }}"
-      vars:
-        releases: >-
-          {{ lookup('url', 'https://api.github.com/repos/paradedb/pg_analytics/releases?per_page=10', split_lines=False) | from_json }}
-        search_pattern: >-
-          {{
-            (ansible_os_family == 'RedHat')
-            | ternary(
-                'pg_analytics_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-                'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
-            )
-          }}
-        match_asset: >-
-          {{
-            releases
-            | map(attribute='assets') | map('default', []) | flatten
-            | selectattr('name', 'match', search_pattern)
-            | list | first | default({})
-          }}
-      check_mode: false
-      when: pg_analytics_version | default('latest') == 'latest'
-
-    - name: "Download pg_analytics package ({{ pg_analytics_package_url | basename }})"
-      ansible.builtin.get_url:
-        url: "{{ pg_analytics_package_url }}"
-        dest: "/tmp/{{ pg_analytics_package_url | basename }}"
-        timeout: 60
-        validate_certs: false
-      register: get_url_status
-      until: get_url_status is succeeded
-      retries: 3
-      delay: 5
-      check_mode: false
-
-    - name: Install pg_analytics package
+    - name: "Install pg_analytics v{{ version }} package"
       ansible.builtin.apt:
-        deb: "/tmp/{{ pg_analytics_package_url | basename }}"
+        deb: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ paradedb_architecture_map_dep[ansible_architecture] }}.deb"
       register: apt_status
-      until: apt_status is succeeded
-      retries: 3
+      until: apt_status is success
       delay: 5
-      when: ansible_os_family == 'Debian'
+      retries: 3
+      vars:
+        pg_analytics_package: 
+      when:
+        - ansible_os_family == "Debian"
+        - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
 
-    - name: Install pg_analytics package
+    - name: "Install pg_analytics v{{ version) }} package"
       ansible.builtin.dnf:
-        name: "/tmp/{{ pg_analytics_package_url | basename }}"
-        state: present
+        name: "{{ pg_analytics_repo }}/pg_analytics_{{ pg_version | default(postgresql_version) }}-{{ version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ paradedb_architecture_map_rpm[ansible_architecture] }}.rpm"
+        disable_gpg_check: true
       register: dnf_status
-      until: dnf_status is succeeded
-      retries: 3
+      until: dnf_status is success
       delay: 5
-      when: ansible_os_family == 'RedHat'
+      retries: 3
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version in ['8', '9']
+  vars:
+    version: "{{ pg_analytics_version | default('0.3.7') }}"
+    pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ version }}/"
   when: enable_paradedb | default(false) | bool or pg_analytics | default(false) | bool
   tags: paradedb, pg_analytics

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -296,11 +296,11 @@
         (
           (ansible_os_family == 'RedHat') | ternary(
             'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (pg_search_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (pg_search_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (pg_search_architecture_map_deb[ansible_architecture]) ~ '\.deb$'
           )
         )
       }}
-    pg_search_architecture_map_dep:
+    pg_search_architecture_map_deb:
       x86_64: amd64
       amd64: amd64
       aarch64: arm64
@@ -318,7 +318,7 @@
 - block:
     - name: "Install pg_analytics v{{ version }} package"
       ansible.builtin.apt:
-        deb: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ pg_analytics_architecture_map_dep[ansible_architecture] }}.deb"
+        deb: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ pg_analytics_architecture_map_deb[ansible_architecture] }}.deb"
       register: apt_status
       until: apt_status is success
       delay: 5
@@ -341,7 +341,7 @@
   vars:
     version: "{{ pg_analytics_version | default('0.3.7') }}"
     pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ version }}/"
-    pg_analytics_architecture_map_dep:
+    pg_analytics_architecture_map_deb:
       x86_64: amd64
       amd64: amd64
       aarch64: arm64

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -294,29 +294,36 @@
 # ParadeDB - https://github.com/paradedb/paradedb
 # pg_search (if 'enable_paradedb' or 'enable_pg_search' is 'true')
 - block:
-    - name: Looking up the latest available pg_search package
+    - name: "Looking up {{ pg_search_version | default('latest available') }} pg_search package"
       ansible.builtin.set_fact:
+        # Set the download URL for the matched package (if found)
         pg_search_package_url: "{{ match_asset.browser_download_url | default('') }}"
       vars:
+        # Fetch and parse the latest 10 release entries from the GitHub API
         releases: >-
           {{ lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases?per_page=10', split_lines=False) | from_json }}
+        # Build regex to match the package by optional version, PG version, OS, arch
         search_pattern: >-
           {{
-            (ansible_os_family == 'RedHat')
-            | ternary(
-                'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-                'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+            '.*'
+            ~ (pg_search_version | default('') ~ '/')
+            ~ (
+              ansible_os_family == 'RedHat'
+              | ternary(
+                  'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+                  'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+              )
             )
           }}
+        # From all available release assets, find the first one matching our pattern
         match_asset: >-
           {{
             releases
             | map(attribute='assets') | map('default', []) | flatten
-            | selectattr('name', 'match', search_pattern)
+            | selectattr('browser_download_url', 'match', search_pattern)
             | list | first | default({})
           }}
       check_mode: false
-      when: pg_search_version | default('latest') == 'latest'
 
     - name: "Download pg_search package ({{ pg_search_package_url | basename }})"
       ansible.builtin.get_url:
@@ -339,7 +346,7 @@
       delay: 5
       when: ansible_os_family == 'Debian'
 
-    - name: "Install pg_search {{ version }} package"
+    - name: Install pg_search package
       ansible.builtin.dnf:
         name: "/tmp/{{ pg_search_package_url | basename }}"
         state: present

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -1,6 +1,8 @@
 ---
 # Extension Auto-Setup: packages
 
+# Note: We use the 'pg_version' variable to be able to reuse this code in the upgrade role.
+
 # TimescaleDB (if 'enable_timescale' is 'true')
 - name: Install TimescaleDB package
   ansible.builtin.package:
@@ -288,96 +290,112 @@
     - ansible_os_family == "Debian"
     - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
 
-# ParadeDB (pg_search, pg_analytics) - https://github.com/paradedb/paradedb
-# (if 'enable_paradedb' or 'enable_pg_search', 'enable_pg_analytics' is 'true')
+# ParadeDB - https://github.com/paradedb/paradedb
+# pg_search (if 'enable_paradedb' or 'enable_pg_search' is 'true')
 - block:
-    # pg_search
-    - block:
-        - name: Looking up the latest version of pg_search
-          ansible.builtin.set_fact:
-            pg_search_version: >-
-              {{
-                (lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases/latest', split_lines=False)
-                | from_json).get('tag_name')
-                | replace('v', '')
-              }}
-          when: pg_search_version | default('latest') == 'latest'
+    - name: Looking up the latest available of pg_search package
+      ansible.builtin.set_fact:
+        pg_search_package_url: "{{ match.browser_download_url }}"
+        pg_search_version: "{{ match.release_tag }}"
+      vars:
+        pg_version: "{{ pg_version | default(postgresql_version) }}"
+        releases: >-
+          {{ lookup('url', 'https://api.github.com/repos/paradedb/paradedb/releases?per_page=10', split_lines=False) | from_json }}
+        pattern: >-
+          {{
+            (ansible_os_family == 'RedHat')
+            | ternary(
+                'pg_search_' ~ pg_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
+                'postgresql-' ~ pg_version ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+            )
+          }}
+        match: >-
+          {{
+            releases
+            | map('extract', 'assets') | map('default', [])
+            | zip(releases)
+            | map('flatten')
+            | selectattr(0, 'name', 'search', pattern)
+            | map('combine', {
+                'browser_download_url': attribute(0, 'browser_download_url'),
+                'release_tag': attribute(1, 'tag_name')
+            })
+            | first
+          }}
+      when: pg_search_version | default('latest') == 'latest'
 
-        # Debian
-        - name: "Install pg_search v{{ pg_search_version }} package"
-          ansible.builtin.apt:
-            deb: "{{ pg_search_package }}"
-          register: apt_status
-          until: apt_status is success
-          delay: 5
-          retries: 3
-          vars:
-            pg_search_repo: "https://github.com/paradedb/paradedb/releases/download/v{{ pg_search_version }}/"
-            pg_search_package: "{{ pg_search_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-search_{{ pg_search_version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ paradedb_architecture_map_dep[ansible_architecture] }}.deb" # yamllint disable rule:line-length
-          when:
-            - ansible_os_family == "Debian"
-            - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
+    - name: Download pg_search {{ pg_search_version }} package
+      ansible.builtin.get_url:
+        url: "{{ pg_search_package_url }}"
+        dest: "/tmp/{{ pg_search_package_url | basename }}"
+        timeout: 60
+        validate_certs: false
+      register: get_url_status
+      until: get_url_status is succeeded
+      retries: 3
+      delay: 5
 
-        # RedHat
-        - name: "Install pg_search v{{ pg_search_version }} package"
-          ansible.builtin.dnf:
-            name: "{{ pg_search_package }}"
-            disable_gpg_check: true
-          register: dnf_status
-          until: dnf_status is success
-          delay: 5
-          retries: 3
-          vars:
-            pg_search_repo: "https://github.com/paradedb/paradedb/releases/download/v{{ pg_search_version }}/"
-            pg_search_package: "{{ pg_search_repo }}/pg_search_{{ pg_version | default(postgresql_version) }}-{{ pg_search_version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ paradedb_architecture_map_rpm[ansible_architecture] }}.rpm" # yamllint disable rule:line-length
-          when:
-            - ansible_os_family == "RedHat"
-            - ansible_distribution_major_version in ['8', '9']
-      when: (enable_paradedb | default(false) | bool) or (enable_pg_search | default(false) | bool)
+    - name: Install pg_search {{ pg_search_version }} package
+      ansible.builtin.package:
+        name: "/tmp/{{ pg_search_package_url | basename }}"
+        state: present
+      register: package_status
+      until: package_status is succeeded
+      retries: 3
+      delay: 5
+  when: enable_paradedb | default(false) | bool or pg_search | default(false) | bool
+  tags: paradedb, pg_search
 
-    # pg_analytics
-    - block:
-        - name: Looking up the latest version of pg_analytics
-          ansible.builtin.set_fact:
-            pg_analytics_version: >-
-              {{
-                (lookup('url', 'https://api.github.com/repos/paradedb/pg_analytics/releases/latest', split_lines=False)
-                | from_json).get('tag_name')
-                | replace('v', '')
-              }}
-          when: pg_analytics_version | default('latest') == 'latest'
+# pg_analytics (if 'enable_paradedb' or 'enable_pg_analytics' is 'true')
+- block:
+    - name: Looking up the latest available of pg_analytics package
+      ansible.builtin.set_fact:
+        pg_analytics_package_url: "{{ match.browser_download_url }}"
+        pg_analytics_version: "{{ match.release_tag }}"
+      vars:
+        pg_version: "{{ pg_version | default(postgresql_version) }}"
+        releases: >-
+          {{ lookup('url', 'https://api.github.com/repos/paradedb/pg_analytics/releases?per_page=10', split_lines=False) | from_json }}
+        pattern: >-
+          {{
+            (ansible_os_family == 'RedHat')
+            | ternary(
+                'pg_analytics_' ~ pg_version ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ ansible_architecture ~ '\\.rpm$',
+                'postgresql-' ~ pg_version ~ '-pg-analytics_.*' ~ ansible_distribution_release ~ '.*' ~ ansible_architecture ~ '\\.deb$'
+            )
+          }}
+        match: >-
+          {{
+            releases
+            | map('extract', 'assets') | map('default', [])
+            | zip(releases)
+            | map('flatten')
+            | selectattr(0, 'name', 'search', pattern)
+            | map('combine', {
+                'browser_download_url': attribute(0, 'browser_download_url'),
+                'release_tag': attribute(1, 'tag_name')
+            })
+            | first
+          }}
 
-        # Debian
-        - name: "Install pg_analytics v{{ pg_analytics_version }} package"
-          ansible.builtin.apt:
-            deb: "{{ pg_analytics_package }}"
-          register: apt_status
-          until: apt_status is success
-          delay: 5
-          retries: 3
-          vars:
-            pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ pg_analytics_version }}/"
-            pg_analytics_package: "{{ pg_analytics_repo }}/postgresql-{{ pg_version | default(postgresql_version) }}-pg-analytics_{{ pg_analytics_version }}-1PARADEDB-{{ ansible_distribution_release }}_{{ paradedb_architecture_map_dep[ansible_architecture] }}.deb" # yamllint disable rule:line-length
-          when:
-            - ansible_os_family == "Debian"
-            - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
+    - name: Download pg_analytics {{ pg_analytics_version }} package
+      ansible.builtin.get_url:
+        url: "{{ pg_analytics_package_url }}"
+        dest: "/tmp/{{ pg_analytics_package_url | basename }}"
+        timeout: 60
+        validate_certs: false
+      register: get_url_status
+      until: get_url_status is succeeded
+      retries: 3
+      delay: 5
 
-        # RedHat
-        - name: "Install pg_analytics v{{ pg_analytics_version }} package"
-          ansible.builtin.dnf:
-            name: "{{ pg_analytics_package }}"
-            disable_gpg_check: true
-          register: dnf_status
-          until: dnf_status is success
-          delay: 5
-          retries: 3
-          vars:
-            pg_analytics_repo: "https://github.com/paradedb/pg_analytics/releases/download/v{{ pg_analytics_version }}/"
-            pg_analytics_package: "{{ pg_analytics_repo }}/pg_analytics_{{ pg_version | default(postgresql_version) }}-{{ pg_analytics_version }}-1PARADEDB.el{{ ansible_distribution_major_version }}.{{ paradedb_architecture_map_rpm[ansible_architecture] }}.rpm" # yamllint disable rule:line-length
-          when:
-            - ansible_os_family == "RedHat"
-            - ansible_distribution_major_version in ['8', '9']
-      when: (enable_paradedb | default(false) | bool) or (enable_pg_analytics | default(false) | bool)
-  when: (enable_paradedb | default(false) | bool) or (enable_pg_search | default(false) | bool) or (enable_pg_analytics | default(false) | bool)
-  tags: paradedb, pg_search, pg_analytics
-# Note: We use the 'pg_version' variable to be able to reuse this code in the upgrade role.
+    - name: Install pg_analytics {{ pg_analytics_version }} package
+      ansible.builtin.package:
+        name: "/tmp/{{ pg_analytics_package_url | basename }}"
+        state: present
+      register: package_status
+      until: package_status is succeeded
+      retries: 3
+      delay: 5
+  when: enable_paradedb | default(false) | bool or pg_analytics | default(false) | bool
+  tags: paradedb, pg_analytics

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -295,8 +295,8 @@
         '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '') ~
         (
           (ansible_os_family == 'RedHat') | ternary(
-            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (pg_search_architecture_map_dep[ansible_architecture]) ~ '\.rpm$',
-            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (pg_search_architecture_map_rpm[ansible_architecture]) ~ '\.deb$'
+            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (pg_search_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (pg_search_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
           )
         )
       }}

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -302,7 +302,7 @@
     # Build regex to match the package by optional version, PG version, OS, arch
     search_pattern: >-
       {{
-        '.*' ~ (extension_version | default('') ~ '/')
+        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '')
         ~ (
           ansible_os_family == 'RedHat'
           | ternary(

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 # Extension Auto-Setup: packages
 

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -293,7 +293,7 @@
 # ParadeDB - https://github.com/paradedb/paradedb
 # pg_search (if 'enable_paradedb' or 'enable_pg_search' is 'true')
 - block:
-    - name: Looking up the latest available of pg_search package
+    - name: Looking up the latest available pg_search package
       ansible.builtin.set_fact:
         pg_search_package_url: "{{ match.browser_download_url }}"
         pg_search_version: "{{ match.release_tag }}"
@@ -312,14 +312,21 @@
         match: >-
           {{
             releases
-            | map('extract', 'assets') | map('default', [])
-            | zip(releases)
-            | map('flatten')
-            | selectattr(0, 'name', 'search', pattern)
+            | selectattr('assets', 'defined')
             | map('combine', {
-                'browser_download_url': attribute(0, 'browser_download_url'),
-                'release_tag': attribute(1, 'tag_name')
-            })
+                'matched_asset': (
+                  attribute('assets')
+                  | selectattr('name', 'search', pattern)
+                  | list
+                  | first
+                )
+              })
+            | selectattr('matched_asset', 'defined')
+            | map('combine', {
+                'browser_download_url': attribute('matched_asset', 'browser_download_url'),
+                'release_tag': attribute('tag_name') | replace('v', '')
+              })
+            | list
             | first
           }}
       when: pg_search_version | default('latest') == 'latest'
@@ -348,7 +355,7 @@
 
 # pg_analytics (if 'enable_paradedb' or 'enable_pg_analytics' is 'true')
 - block:
-    - name: Looking up the latest available of pg_analytics package
+    - name: Looking up the latest available pg_analytics package
       ansible.builtin.set_fact:
         pg_analytics_package_url: "{{ match.browser_download_url }}"
         pg_analytics_version: "{{ match.release_tag }}"
@@ -367,14 +374,21 @@
         match: >-
           {{
             releases
-            | map('extract', 'assets') | map('default', [])
-            | zip(releases)
-            | map('flatten')
-            | selectattr(0, 'name', 'search', pattern)
+            | selectattr('assets', 'defined')
             | map('combine', {
-                'browser_download_url': attribute(0, 'browser_download_url'),
-                'release_tag': attribute(1, 'tag_name')
-            })
+                'matched_asset': (
+                  attribute('assets')
+                  | selectattr('name', 'search', pattern)
+                  | list
+                  | first
+                )
+              })
+            | selectattr('matched_asset', 'defined')
+            | map('combine', {
+                'browser_download_url': attribute('matched_asset', 'browser_download_url'),
+                'release_tag': attribute('tag_name') | replace('v', '')
+              })
+            | list
             | first
           }}
 

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -2,25 +2,16 @@
 ---
 # reusable task file: extensions_github.yml
 #
+# Extension Auto-Setup: packages fron GitHub
+#
 # Incoming options:
 # - github_repo (e.q, 'paradedb/paradedb')
 # - extension_name (e.q., 'pg_search')
 # - extension_version (e.q., '0.15.18') - optional
 # - search_pattern (search in assets.browser_download_url)
-#
-# Example of a search pattern:
-#    search_pattern: >-
-#      {{
-#        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '') ~
-#        (
-#          (ansible_os_family == 'RedHat') | ternary(
-#            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-#            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
-#          )
-#        )
-#      }}
+# - package_name_pattern - required when installing a file extracted from an archive.
 
-- name: "Looking up {{ extension_version | default('latest available') }} {{ extension_name }} package"
+- name: "Looking up {{ extension_version if extension_version | default('') | length > 0 else 'latest available' }} {{ extension_name }} package"
   ansible.builtin.set_fact:
     # Set the download URL for the matched package (if found)
     github_package_url: "{{ match_asset.browser_download_url | default('') }}"
@@ -49,7 +40,7 @@
   check_mode: false
   when: github_package_url | length == 0
 
-# If found, download and install
+# If found, download it
 - name: "Download {{ extension_name }} package ({{ github_package_url | basename }})"
   ansible.builtin.get_url:
     url: "{{ github_package_url }}"
@@ -60,25 +51,67 @@
   until: get_url_status is succeeded
   retries: 3
   delay: 5
-  check_mode: false
   when: github_package_url | length > 0
 
-- name: "Install {{ extension_name }} package"
-  ansible.builtin.apt:
-    deb: "/tmp/{{ github_package_url | basename }}"
-  register: apt_status
-  until: apt_status is succeeded
-  retries: 3
-  delay: 5
-  when: ansible_os_family == 'Debian' and github_package_url | length > 0
+# If it's an archive, unzip it
+- block:
+    - name: "Unarchive {{ extension_name }} package"
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ github_package_url | basename }}"
+        dest: "/tmp/{{ extension_name }}"
+        remote_src: true
 
-- name: "Install {{ extension_name }} package"
-  ansible.builtin.dnf:
-    name: "/tmp/{{ github_package_url | basename }}"
-    state: present
-    disable_gpg_check: true
-  register: dnf_status
-  until: dnf_status is succeeded
-  retries: 3
-  delay: 5
-  when: ansible_os_family == 'RedHat' and github_package_url | length > 0
+    - name: "Search for {{ extension_name }} package in extracted archive"
+      ansible.builtin.find:
+        paths: "/tmp/{{ extension_name }}"
+        patterns: "{{ package_name_pattern }}"
+        use_regex: true
+      register: extracted_package
+      when: package_name_pattern is defined
+  when:
+    - github_package_url | length > 0
+    - github_package_url | regex_search('\.(zip|tar\.gz)$')
+
+# Install
+- block:
+    - name: "Install {{ extension_name }} package"
+      ansible.builtin.apt:
+        deb: "{{ item }}"
+      loop: "{{ files_to_install | select('match', '\\.deb$') | list }}"
+      register: apt_status
+      until: apt_status is succeeded
+      retries: 3
+      delay: 5
+      when: ansible_os_family == 'Debian'
+
+    - name: "Install {{ extension_name }} package"
+      ansible.builtin.dnf:
+        name: "{{ item }}"
+        state: present
+        disable_gpg_check: true
+      loop: "{{ files_to_install | select('match', '\\.rpm$') | list }}"
+      register: dnf_status
+      until: dnf_status is succeeded
+      retries: 3
+      delay: 5
+      when: ansible_os_family == 'RedHat'
+  vars:
+    files_to_install: >-
+      {{
+        (extracted_package is defined and extracted_package.files is defined and extracted_package.files | length > 0)
+        | ternary(
+            extracted_package.files | map(attribute='path') | list,
+            ["/tmp/" ~ github_package_url | basename]
+        )
+      }}
+  when: github_package_url | length > 0
+
+# Clean up
+- name: Clean up downloaded files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/{{ github_package_url | basename }}"
+    - "/tmp/{{ extension_name }}"
+  when: github_package_url | length > 0

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -6,11 +6,12 @@
 # - github_repo (e.q, 'paradedb/paradedb')
 # - extension_name (e.q., 'pg_search')
 # - extension_version (e.q., '0.15.18') - optional
-# - search_pattern
+# - search_pattern (search in assets.browser_download_url)
 #
 # Example of a search pattern:
+#    search_pattern: >-
 #      {{
-#        '.*' ~ (pg_search_version | default('') ~ '/')
+#        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '')
 #        ~ (
 #          ansible_os_family == 'RedHat'
 #          | ternary(

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -11,12 +11,11 @@
 # Example of a search pattern:
 #    search_pattern: >-
 #      {{
-#        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '')
-#        ~ (
-#          ansible_os_family == 'RedHat'
-#          | ternary(
-#              'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
-#              'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+#        '.*' ~ (pg_search_version ~ '/' if pg_search_version is defined else '') ~
+#        (
+#          (ansible_os_family == 'RedHat') | ternary(
+#            'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+#            'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
 #          )
 #        )
 #      }}

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -87,32 +87,34 @@
     - name: "Install {{ extension_name }} package"
       ansible.builtin.apt:
         deb: "{{ item }}"
-      loop: "{{ files_to_install | select('match', '\\.deb$') | list }}"
+      loop: "{{ files_to_install }}"
+      loop_control:
+        label: "{{ item | basename }}"
       register: apt_status
       until: apt_status is succeeded
       retries: 3
       delay: 5
-      when: ansible_os_family == 'Debian'
+      when: ansible_os_family == 'Debian' and item is search('\.deb$')
 
     - name: "Install {{ extension_name }} package"
       ansible.builtin.dnf:
         name: "{{ item }}"
         state: present
         disable_gpg_check: true
-      loop: "{{ files_to_install | select('match', '\\.rpm$') | list }}"
+      loop: "{{ files_to_install }}"
+      loop_control:
+        label: "{{ item | basename }}"
       register: dnf_status
       until: dnf_status is succeeded
       retries: 3
       delay: 5
-      when: ansible_os_family == 'RedHat'
+      when: ansible_os_family == 'RedHat' and item is search('\.rpm$')
   ignore_errors: true
   vars:
     files_to_install: >-
       {{
-        (extracted_package is defined and (extracted_package.files | default([]) | length > 0))
-        | ternary(
-            extracted_package.files | map(attribute='path') | list,
-            ["/tmp/" ~ github_package_url | basename]
-        )
+        extracted_package.files | map(attribute='path') | reject('search', 'dbgsym') | list
+        if extracted_package is defined and extracted_package.files is defined
+        else ['/tmp/' ~ github_package_url | basename]
       }}
   when: github_package_url | length > 0

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -58,16 +58,26 @@
     - name: "Unarchive {{ extension_name }} package"
       ansible.builtin.unarchive:
         src: "/tmp/{{ github_package_url | basename }}"
-        dest: "/tmp/{{ extension_name }}"
+        dest: "/tmp/"
         remote_src: true
 
     - name: "Search for {{ extension_name }} package in extracted archive"
       ansible.builtin.find:
-        paths: "/tmp/{{ extension_name }}"
+        paths: "/tmp/"
         patterns: "{{ package_name_pattern }}"
         use_regex: true
       register: extracted_package
       when: package_name_pattern is defined
+
+    - name: "ERROR: No matching {{ extension_name }} package found"
+      run_once: true
+      ansible.builtin.fail:
+        msg: >-
+          ERROR: No matching {{ extension_name }} package found.
+          Search pattern: {{ package_name_pattern }}
+      ignore_errors: true
+      check_mode: false
+      when: extracted_package is defined and extracted_package.files | default([]) | length == 0
   when:
     - github_package_url | length > 0
     - github_package_url | regex_search('\.(zip|tar\.gz)$')
@@ -95,23 +105,14 @@
       retries: 3
       delay: 5
       when: ansible_os_family == 'RedHat'
+  ignore_errors: true
   vars:
     files_to_install: >-
       {{
-        (extracted_package is defined and extracted_package.files is defined and extracted_package.files | length > 0)
+        (extracted_package is defined and extracted_package.files | default([]) | length > 0)
         | ternary(
             extracted_package.files | map(attribute='path') | list,
             ["/tmp/" ~ github_package_url | basename]
         )
       }}
-  when: github_package_url | length > 0
-
-# Clean up
-- name: Clean up downloaded files
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - "/tmp/{{ github_package_url | basename }}"
-    - "/tmp/{{ extension_name }}"
   when: github_package_url | length > 0

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -109,7 +109,7 @@
   vars:
     files_to_install: >-
       {{
-        (extracted_package is defined and extracted_package.files | default([]) | length > 0)
+        (extracted_package is defined and (extracted_package.files | default([]) | length > 0))
         | ternary(
             extracted_package.files | map(attribute='path') | list,
             ["/tmp/" ~ github_package_url | basename]

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -1,0 +1,82 @@
+---
+# reusable task file: extensions_github.yml
+#
+# Incoming options:
+# - github_repo (e.q, 'paradedb/paradedb')
+# - extension_name (e.q., 'pg_search')
+# - extension_version (e.q., '0.15.18') - optional
+# - search_pattern
+#
+# Example of a search pattern: 
+#      {{
+#        '.*' ~ (pg_search_version | default('') ~ '/')
+#        ~ (
+#          ansible_os_family == 'RedHat'
+#          | ternary(
+#              'pg_search_' ~ (pg_version | default(postgresql_version)) ~ '.*el' ~ ansible_distribution_major_version ~ '.*' ~ (paradedb_architecture_map_rpm[ansible_architecture]) ~ '\.rpm$',
+#              'postgresql-' ~ (pg_version | default(postgresql_version)) ~ '-pg-search_.*' ~ ansible_distribution_release ~ '.*' ~ (paradedb_architecture_map_dep[ansible_architecture]) ~ '\.deb$'
+#          )
+#        )
+#      }}
+
+- name: "Looking up {{ extension_version | default('latest available') }} {{ extension_name }} package"
+  ansible.builtin.set_fact:
+    # Set the download URL for the matched package (if found)
+    github_package_url: "{{ match_asset.browser_download_url | default('') }}"
+  vars:
+    # Fetch and parse the latest 10 release entries from the GitHub API
+    releases: >-
+      {{ lookup('url', 'https://api.github.com/repos/' ~ github_repo ~ '/releases?per_page=10', split_lines=False) | from_json }}
+    # From all available release assets, find the first one matching our pattern
+    match_asset: >-
+      {{
+        releases
+        | map(attribute='assets') | map('default', []) | flatten
+        | selectattr('browser_download_url', 'match', search_pattern)
+        | list | first | default({})
+      }}
+  check_mode: false
+
+# If not found, show the error and continue the playbook execution
+- name: "ERROR: No matching {{ extension_name }} package found for this system"
+  run_once: true
+  ansible.builtin.fail:
+    msg: >-
+      ERROR: No matching {{ extension_name }} package found.
+      Search pattern: {{ search_pattern }}
+  ignore_errors: true
+  check_mode: false
+  when: github_package_url | length == 0
+
+# If found, download and install
+- name: "Download {{ extension_name }} package ({{ github_package_url | basename }})"
+  ansible.builtin.get_url:
+    url: "{{ github_package_url }}"
+    dest: "/tmp/{{ github_package_url | basename }}"
+    timeout: 60
+    validate_certs: false
+  register: get_url_status
+  until: get_url_status is succeeded
+  retries: 3
+  delay: 5
+  check_mode: false
+  when: github_package_url | length > 0
+
+- name: "Install {{ extension_name }} package"
+  ansible.builtin.apt:
+    deb: "/tmp/{{ github_package_url | basename }}"
+  register: apt_status
+  until: apt_status is succeeded
+  retries: 3
+  delay: 5
+  when: ansible_os_family == 'Debian' and github_package_url | length > 0
+
+- name: "Install {{ extension_name }} package"
+  ansible.builtin.dnf:
+    name: "/tmp/{{ github_package_url | basename }}"
+    state: present
+  register: dnf_status
+  until: dnf_status is succeeded
+  retries: 3
+  delay: 5
+  when: ansible_os_family == 'RedHat' and github_package_url | length > 0

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 # reusable task file: extensions_github.yml
 #
@@ -7,7 +8,7 @@
 # - extension_version (e.q., '0.15.18') - optional
 # - search_pattern
 #
-# Example of a search pattern: 
+# Example of a search pattern:
 #      {{
 #        '.*' ~ (pg_search_version | default('') ~ '/')
 #        ~ (

--- a/automation/roles/packages/tasks/extensions_github.yml
+++ b/automation/roles/packages/tasks/extensions_github.yml
@@ -76,6 +76,7 @@
   ansible.builtin.dnf:
     name: "/tmp/{{ github_package_url | basename }}"
     state: present
+    disable_gpg_check: true
   register: dnf_status
   until: dnf_status is succeeded
   retries: 3

--- a/automation/roles/pre_checks/tasks/extensions.yml
+++ b/automation/roles/pre_checks/tasks/extensions.yml
@@ -43,11 +43,11 @@
   ansible.builtin.fail:
     msg:
       - "ParadeDB (pg_search, pg_analytics) is not supported on {{ ansible_distribution }} {{ ansible_distribution_release }}."
-      - "Supported OS: Debian (bookworm), Ubuntu (jammy, noble) or RedHat (8, 9)."
+      - "Supported OS: Debian (bullseye, bookworm), Ubuntu (jammy, noble) or RedHat (8, 9)."
   when:
     - (enable_paradedb | default(false) | bool) or (enable_pg_search | default(false) | bool) or (enable_pg_analytics | default(false) | bool)
     - not (
-      (ansible_os_family == "Debian" and ansible_distribution_release in ['bookworm', 'jammy', 'noble']) or
+      (ansible_os_family == "Debian" and ansible_distribution_release in ['bullseye', 'bookworm', 'jammy', 'noble']) or
       (ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9'])
       )
 

--- a/automation/tags.md
+++ b/automation/tags.md
@@ -3,7 +3,6 @@
 - add_repo
 - - install_epel_repo
 - - install_postgresql_repo
-- - install_scl_repo
 - install_packages
 - - install_postgres
 - - install_packages_from_file


### PR DESCRIPTION
This PR improves the installation logic for the latest versions of extensions for "[Extension Auto-Setup](https://autobase.tech/docs/extensions/install#method-1-auto-setup)" mode.

### Changes:
- Instead of using the latest tag from GitHub API, we now search for the latest release that includes a matching package file (based on OS, PostgreSQL version, architecture, etc).
- This:
    - Eliminates failures when a release tag exists but the package is not yet uploaded.
    - Improves resilience to minor filename changes, by using regex matching instead of hardcoded patterns.

### Other Changes:

- Disable Docker push for PR
- Add "Extension Auto-Setup" to pg_upgrade Molecule test