### PR TITLE
Fix Patroni package installation error on RHEL 8

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -157,22 +157,23 @@
 - block: # installation_method: "repo" and patroni_installation_method: "rpm/deb"
     # Debian
     - name: Install patroni package
-      ansible.builtin.package:
+      ansible.builtin.apt:
         name: "{{ patroni_packages | flatten }}"
         state: present
-      register: package_status
-      until: package_status is success
+      register: apt_status
+      until: apt_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "Debian" and patroni_deb_package_repo | length < 1
 
     # RedHat
     - name: Install patroni package
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "{{ patroni_packages | flatten }}"
         state: present
-      register: package_status
-      until: package_status is success
+        disable_gpg_check: true
+      register: dnf_status
+      until: dnf_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length < 1
@@ -194,8 +195,8 @@
         deb: "/tmp/{{ item }}"
         state: present
       loop: "{{ patroni_deb_package_repo | map('basename') | list }}"
-      register: apt_status
-      until: apt_status is success
+      register: deb_package_status
+      until: deb_package_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "Debian" and patroni_deb_package_repo | length > 0
@@ -211,12 +212,13 @@
       when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
 
     - name: Install patroni from rpm package
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "/tmp/{{ item }}"
         state: present
+        disable_gpg_check: true
       loop: "{{ patroni_rpm_package_repo | map('basename') | list }}"
-      register: package_status
-      until: package_status is success
+      register: rpm_package_status
+      until: rpm_package_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
@@ -238,8 +240,8 @@
         force_apt_get: true
         deb: "/tmp/{{ patroni_deb_package_file | basename }}"
         state: present
-      register: apt_status
-      until: apt_status is success
+      register: deb_package_file_status
+      until: deb_package_file_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "Debian"
@@ -252,11 +254,12 @@
       when: ansible_os_family == "RedHat"
 
     - name: Install patroni from rpm package
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "/tmp/{{ patroni_rpm_package_file | basename }}"
         state: present
-      register: package_status
-      until: package_status is success
+        disable_gpg_check: true
+      register: rpm_package_file_status
+      until: rpm_package_file_status is success
       delay: 5
       retries: 3
       when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Add `disable_gpg_check` option to `ansible.builtin.dnf` module.

Fixed:

```
  fatal: [10.172.0.20]: FAILED! => {"attempts": 3, "changed": false, "msg": "Failed to validate GPG signature for python3.12-etcd-0.4.5-48PGDG.rhel8.noarch: Package python3.12-etcd-0.4.5-48PGDG.rhel8.noarch.rpm is not signed"}
  fatal: [10.172.0.21]: FAILED! => {"attempts": 3, "changed": false, "msg": "Failed to validate GPG signature for python3.12-etcd-0.4.5-48PGDG.rhel8.noarch: Package python3.12-etcd-0.4.5-48PGDG.rhel8.noarch.rpm is not signed"}
  fatal: [10.172.0.22]: FAILED! => {"attempts": 3, "changed": false, "msg": "Failed to validate GPG signature for python3.12-etcd-0.4.5-48PGDG.rhel8.noarch: Package python3.12-etcd-0.4.5-48PGDG.rhel8.noarch.rpm is not signed"}
  FAILED - RETRYING: [10.172.0.21]: Install patroni package (3 retries left).
  FAILED - RETRYING: [10.172.0.20]: Install patroni package (3 retries left).
  FAILED - RETRYING: [10.172.0.22]: Install patroni package (3 retries left).
  FAILED - RETRYING: [10.172.0.21]: Install patroni package (2 retries left).
  FAILED - RETRYING: [10.172.0.20]: Install patroni package (2 retries left).
  FAILED - RETRYING: [10.172.0.22]: Install patroni package (2 retries left).
  FAILED - RETRYING: [10.172.0.21]: Install patroni package (1 retries left).
  FAILED - RETRYING: [10.172.0.20]: Install patroni package (1 retries left).
  FAILED - RETRYING: [10.172.0.22]: Install patroni package (1 retries left).
  
  TASK [vitabaks.autobase.patroni : Install patroni package] *********************
```