### PR TITLE
update_pgcluster: Fix become_user for pgbackrest host tasks

### DIFF
--- a/automation/roles/update/tasks/pgbackrest_host.yml
+++ b/automation/roles/update/tasks/pgbackrest_host.yml
@@ -37,6 +37,8 @@
       until: update_pgbackrest_package is success
       delay: 5
       retries: 3
+  become: true
+  become_user: root
   when:
     - pgbackrest_install | bool
     - pgbackrest_repo_host | default('') | length > 0


### PR DESCRIPTION
Fixed:

```
TASK [Update pgBackRest package (Dedicated Repository Host)] ******************* ...
TASK [update : Update apt cache] *********************************************** fatal: [**.***.**.9 -> **.***.**.35]: FAILED! => {"attempts": 3, "changed": false, "msg": "Failed to lock apt for exclusive operation: Failed to lock directory /var/lib/apt/lists/: E:Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)"}
```