### PR TITLE
Docs: Update to Run Console using Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,36 +154,20 @@ docker run -d --name autobase-console \
   --restart=unless-stopped \
   autobase/console:latest
 ```
-Alternatively, you can use Docker Compose. Create a `docker-compose.yml` file with the following content:
+Alternatively, you can use Docker Compose:
 
-```yaml
-version: '3.8'
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/vitabaks/autobase.git
+   cd autobase
+   ```
 
-services:
-  autobase-console:
-    image: autobase/console:latest
-    container_name: autobase-console
-    ports:
-      - "80:80"
-      - "8080:8080"
-    environment:
-      - PG_CONSOLE_API_URL=http://localhost:8080/api/v1
-      - PG_CONSOLE_AUTHORIZATION_TOKEN=secret_token
-      - PG_CONSOLE_DOCKER_IMAGE=autobase/automation:latest
-    volumes:
-      - console_postgres:/var/lib/postgresql
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp/ansible:/tmp/ansible
-    restart: unless-stopped
-
-volumes:
-  console_postgres:
-```
-
-Then run:
-```sh
-docker compose up -d
-```
+2. Navigate to the `console` directory and run Docker Compose:
+   ```sh
+   cd console
+   docker compose up -d
+   ```
+You can find the Docker Compose file at [`console/docker-compose.yml`](console/docker-compose.yml:1).
 
 > [!NOTE]
 > If you are running the console on a dedicated server (rather than on your laptop), replace `localhost` with the server’s IP address in the `PG_CONSOLE_API_URL` variable.

--- a/README.md
+++ b/README.md
@@ -154,26 +154,14 @@ docker run -d --name autobase-console \
   --restart=unless-stopped \
   autobase/console:latest
 ```
-Alternatively, you can use Docker Compose:
-
-1. Clone the repository:
-   ```sh
-   git clone https://github.com/vitabaks/autobase.git
-   cd autobase
-   ```
-
-2. Navigate to the `console` directory and run Docker Compose:
-   ```sh
-   cd console
-   docker compose up -d
-   ```
-You can find the Docker Compose file at [`console/docker-compose.yml`](console/docker-compose.yml:1).
 
 > [!NOTE]
 > If you are running the console on a dedicated server (rather than on your laptop), replace `localhost` with the server’s IP address in the `PG_CONSOLE_API_URL` variable.
 
 > [!TIP]
 > It is recommended to run the console in the same network as your database servers to enable monitoring of the cluster status.
+
+Alternatively, you can use [Docker Compose](console/README.md).
 
 **Open the Console UI**:
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,36 @@ docker run -d --name autobase-console \
   --restart=unless-stopped \
   autobase/console:latest
 ```
+Alternatively, you can use Docker Compose. Create a `docker-compose.yml` file with the following content:
+
+```yaml
+version: '3.8'
+
+services:
+  autobase-console:
+    image: autobase/console:latest
+    container_name: autobase-console
+    ports:
+      - "80:80"
+      - "8080:8080"
+    environment:
+      - PG_CONSOLE_API_URL=http://localhost:8080/api/v1
+      - PG_CONSOLE_AUTHORIZATION_TOKEN=secret_token
+      - PG_CONSOLE_DOCKER_IMAGE=autobase/automation:latest
+    volumes:
+      - console_postgres:/var/lib/postgresql
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/ansible:/tmp/ansible
+    restart: unless-stopped
+
+volumes:
+  console_postgres:
+```
+
+Then run:
+```sh
+docker compose up -d
+```
 
 > [!NOTE]
 > If you are running the console on a dedicated server (rather than on your laptop), replace `localhost` with the server’s IP address in the `PG_CONSOLE_API_URL` variable.

--- a/console/README.md
+++ b/console/README.md
@@ -1,33 +1,42 @@
-# Console Stack
+# Autobase Console Stack
 
 Autobase stack running with Caddy as reverse proxy. The stack includes:
 
-- Caddy reverse proxy with automatic HTTPS
+- Caddy (reverse proxy with automatic HTTPS)
 - Console API
 - Console UI
-- PostgreSQL database
+- Console Database (PostgreSQL)
+
+You can find the Docker Compose file at [`console/docker-compose.yml`](docker-compose.yml)
 
 ## Quick Start
 
-1. Setup environment:
+1. Clone the repository:
+    ```sh
+    git clone https://github.com/vitabaks/autobase.git
+    ```
 
-```bash
-cp .env.example .env
-```
+2. Navigate to the `console` directory:
+    ```sh
+    cd autobase/console
+    ```
 
-2. Configure your `.env`:
+3. Setup environment:
+    ```sh
+    cp .env.example .env
+    ```
 
-```bash
-DOMAIN=your-domain.com  # Set your domain
-EMAIL=your@email.com    # Required for Caddy SSL
-AUTH_TOKEN=your-token   # Your authorization token
-```
+4. Configure your `.env`:
+    ```sh
+    DOMAIN=your-domain.com  # Set your domain
+    EMAIL=your@email.com    # Required for Caddy SSL
+    AUTH_TOKEN=your-token   # Your authorization token
+    ```
 
-3. Run the stack:
-
-```bash
-docker compose up -d
-```
+5. Run Docker Compose:
+    ```sh
+    docker compose up -d
+    ```
 
 ## Notes
 

--- a/console/README.md
+++ b/console/README.md
@@ -5,7 +5,7 @@ Autobase stack running with Caddy as reverse proxy. The stack includes:
 - Caddy (reverse proxy with automatic HTTPS)
 - Console API
 - Console UI
-- Console Database (PostgreSQL)
+- Console DB (PostgreSQL)
 
 You can find the Docker Compose file at [`console/docker-compose.yml`](docker-compose.yml)
 


### PR DESCRIPTION
This one allow the devs to have options to run using docker compose instead only on docker-cli (easier to read or edit for the devs)