### PR TITLE
Remove the offline installation method

### DIFF
--- a/automation/playbooks/add_balancer.yml
+++ b/automation/playbooks/add_balancer.yml
@@ -38,7 +38,7 @@
       when:
         - new_node | default(false) | bool
         - ansible_os_family == "Debian"
-        - installation_method | default('repo') == "repo"
+        - installation_method | default('packages') == "packages"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       ansible.builtin.apt:
@@ -54,7 +54,7 @@
       when:
         - new_node | default(false) | bool
         - ansible_os_family == "Debian"
-        - installation_method | default('repo') == "repo"
+        - installation_method | default('packages') == "packages"
 
     - name: Build a firewall_ports_dynamic_var
       ansible.builtin.set_fact:

--- a/automation/playbooks/add_pgnode.yml
+++ b/automation/playbooks/add_pgnode.yml
@@ -52,7 +52,7 @@
       when:
         - new_node | default(false) | bool
         - ansible_os_family == "Debian"
-        - installation_method | default('repo') == "repo"
+        - installation_method | default('packages') == "packages"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       ansible.builtin.apt:
@@ -68,7 +68,7 @@
       when:
         - new_node | default(false) | bool
         - ansible_os_family == "Debian"
-        - installation_method | default('repo') == "repo"
+        - installation_method | default('packages') == "packages"
 
     - name: Build a firewall_ports_dynamic_var
       ansible.builtin.set_fact:

--- a/automation/playbooks/balancers.yml
+++ b/automation/playbooks/balancers.yml
@@ -18,7 +18,7 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       ansible.builtin.apt:
@@ -31,7 +31,7 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Build a firewall_ports_dynamic_var
       ansible.builtin.set_fact:

--- a/automation/playbooks/consul_cluster.yml
+++ b/automation/playbooks/consul_cluster.yml
@@ -69,7 +69,7 @@
       until: apt_status is success
       delay: 5
       retries: 3
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       ansible.builtin.apt:
@@ -81,7 +81,7 @@
       until: apt_status is success
       delay: 5
       retries: 3
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Make sure the python3-pip package are present
       ansible.builtin.package:

--- a/automation/playbooks/etcd_cluster.yml
+++ b/automation/playbooks/etcd_cluster.yml
@@ -16,7 +16,7 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       ansible.builtin.apt:
@@ -29,7 +29,7 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method | default('repo') == "repo"
+      when: ansible_os_family == "Debian" and installation_method | default('packages') == "packages"
 
     - name: Build a firewall_ports_dynamic_var
       ansible.builtin.set_fact:

--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -31,7 +31,7 @@
       delay: 5
       retries: 3
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and ansible_os_family == "Debian"
+  when: installation_method == "packages" and ansible_os_family == "Debian"
   tags: add_repo
 
 - block: # RedHat/CentOS
@@ -159,9 +159,9 @@
         debuginfo_package: "postgresql{{ postgresql_version }}-debuginfo"
       tags: install_postgresql_repo, debuginfo
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and ansible_os_family == "RedHat"
+  when: installation_method == "packages" and ansible_os_family == "RedHat"
   tags: add_repo
 
 - name: Extensions repository
   ansible.builtin.import_tasks: extensions.yml
-  when: installation_method == "repo"
+  when: installation_method == "packages"

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1100,10 +1100,15 @@ etcd_package_repo: "https://github.com/etcd-io/etcd/releases/download/v{{ etcd_v
 vip_manager_package_repo: "https://github.com/cybertec-postgresql/vip-manager/releases/download/v{{ vip_manager_version }}/vip-manager_{{ vip_manager_version }}_Linux_{{ vip_manager_architecture_map[ansible_architecture] }}.{{ pkg_type }}" # yamllint disable rule:line-length
 confd_package_repo: "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-{{ confd_architecture_map[ansible_architecture] }}"
 
+# You can also download the deb/rpm packages into the 'files/' directory.
+# Packages from this directory will be used during installation (optional).
+packages_from_file: []
+#  - "<package_file_name>.{{ pkg_type }}"
+
 # ----------------------------------------------------------------------------------------------------
 # Redefine the installation method (optional)
 # ----------------------------------------------------------------------------------------------------
-installation_method: "repo" # "repo" (default) or "file"
+installation_method: "packages" # "packages" = install via deb/rpm packages; "docker" = use container images (TODO).
 
 # The Patroni package will be installed from the deb/rpm package by default.
 # You also have the option of choosing an installation method using the pip package.
@@ -1127,13 +1132,14 @@ patroni_rpm_package_repo: []
 
 # if patroni_installation_method: "pip"
 patroni_install_version: "latest" # or a specific version (e.q., '4.0.5')
-# pip packages are installed from the public PyPI repository. You can preload the pip packages to your own repository.
-pip_package_repo: "https://bootstrap.pypa.io/get-pip.py" # latest version pip3 for python3 (or use "pip-<version>.tar.gz").
+# pip packages are installed from the public PyPI repository.
+# You can preload the pip packages to your own repository.
 patroni_pip_package_repo: []
 # - "https://<my_repo>/patroni-<version>.tar.gz"
 patroni_pip_requirements_repo: []
 #  - "https://<my_repo>/<package_1>.tar.gz"
 #  - "https://<my_repo>/<package_n>.tar.gz"
+pip_package_repo: "https://bootstrap.pypa.io/get-pip.py" # latest version pip3 for python3 (or use "pip-<version>.tar.gz").
 
 # if with_haproxy_load_balancing: true
 haproxy_installation_method: "{{ pkg_type }}" # deb/rpm or "src"
@@ -1175,39 +1181,6 @@ haproxy_os_specific_packages:
     - openssl-libs
     - systemd-devel
 haproxy_compile_requirements: "{{ haproxy_os_specific_packages[ansible_os_family] }}"
-
-############################################################
-# Offline installation (if installation_method: "file")
-############################################################
-
-# You can also download the required packages into the 'files/' directory.
-# Packages from this directory will be used during installation.
-# Note: You are responsible for providing all required package dependencies for your specific Linux distribution version.
-
-# if patroni_installation_method: "deb" or "rpm"
-patroni_deb_package_file: ""
-patroni_rpm_package_file: ""
-
-# if patroni_installation_method: "pip"
-pip_package_file: ""
-patroni_pip_requirements_file: []
-patroni_pip_package_file: []
-
-# additional packages
-etcd_package_file: ""
-vip_manager_package_file: ""
-wal_g_package_file: ""
-
-# if with_haproxy_load_balancing: true
-haproxy_package_file: []
-confd_package_file: ""
-# if haproxy_installation_method: 'src'
-lua_src_file: ""
-haproxy_src_file: ""
-
-# Specify any required packages, these packages will be installed before all other dependencies (for any installation method).
-packages_from_file: []
-#  - "<package_file_name>.{{ pkg_type }}"
 
 ############################################################
 # Other variables

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1052,6 +1052,15 @@ postgresql_os_specific_packages:
 #   - pg_partman_{{ postgresql_version }}
 postgresql_packages: "{{ postgresql_os_specific_packages[ansible_os_family] }}"
 
+patroni_os_specific_packages:
+  Debian:
+    - python3-{{ dcs_type }}
+  RedHat:
+    - patroni-{{ dcs_type }}
+patroni_packages:
+  - patroni
+  - "{{ patroni_os_specific_packages[ansible_os_family] }}"
+
 python_version: "3" # override the version (e.q, 3.11) only if patroni_installation_method: "pip" is used
 
 system_os_specific_packages:
@@ -1115,15 +1124,6 @@ installation_method: "packages" # "packages" = install via deb/rpm packages; "do
 patroni_installation_method: "{{ pkg_type }}" # deb/rpm (default) or "pip"
 
 # if patroni_installation_method: "deb" or "rpm"
-patroni_os_specific_packages:
-  Debian:
-    - python3-{{ dcs_type }}
-  RedHat:
-    - patroni-{{ dcs_type }}
-patroni_packages:
-  - patroni
-  - "{{ patroni_os_specific_packages[ansible_os_family] }}"
-
 # You can preload the Patroni package to your own repository.
 patroni_deb_package_repo: []
 #  - "https://<my_repo>/patroni_<version>-1.pgdg24.04+1_all.deb"
@@ -1140,47 +1140,6 @@ patroni_pip_requirements_repo: []
 #  - "https://<my_repo>/<package_1>.tar.gz"
 #  - "https://<my_repo>/<package_n>.tar.gz"
 pip_package_repo: "https://bootstrap.pypa.io/get-pip.py" # latest version pip3 for python3 (or use "pip-<version>.tar.gz").
-
-# if with_haproxy_load_balancing: true
-haproxy_installation_method: "{{ pkg_type }}" # deb/rpm or "src"
-
-# if haproxy_installation_method: "src"
-haproxy_major: "{{ haproxy_version.split('.')[:2] | join('.') }}"
-# renovate: datasource=github-tags depName=haproxy/haproxy extractVersion=^v(?<version>.*)$
-haproxy_version: "1.8.31" # version to build from source
-# renovate: datasource=github-releases depName=lua/lua extractVersion=^v(?<version>.*)$
-lua_version: 5.4.7
-lua_src_repo: "https://www.lua.org/ftp/lua-{{ lua_version }}.tar.gz" # required for build haproxy
-haproxy_src_repo: "https://www.haproxy.org/download/{{ haproxy_major }}/src/haproxy-{{ haproxy_version }}.tar.gz"
-haproxy_os_specific_packages:
-  Debian:
-    - unzip
-    - gzip
-    - make
-    - gcc
-    - build-essential
-    - libc6-dev
-    - libpcre3-dev
-    - liblua5.3-dev
-    - libreadline-dev
-    - zlib1g-dev
-    - libsystemd-dev
-    - ca-certificates
-    - libssl-dev
-  RedHat:
-    - unzip
-    - gzip
-    - make
-    - gcc
-    - gcc-c++
-    - pcre-devel
-    - zlib-devel
-    - readline-devel
-    - openssl
-    - openssl-devel
-    - openssl-libs
-    - systemd-devel
-haproxy_compile_requirements: "{{ haproxy_os_specific_packages[ansible_os_family] }}"
 
 ############################################################
 # Other variables

--- a/automation/roles/confd/tasks/main.yml
+++ b/automation/roles/confd/tasks/main.yml
@@ -10,16 +10,7 @@
   loop:
     - "{{ confd_package_repo }}"
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and confd_package_repo | length > 0
-  tags: get_confd, confd
-
-# install confd package from file
-- name: Copy "confd" binary file to /usr/local/bin/
-  ansible.builtin.copy:
-    src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ confd_package_file }}"
-    dest: /usr/local/bin/confd
-    mode: u+x,g+x,o+x
-  when: installation_method == "file" and confd_package_file | length > 0
+  when: installation_method == "packages" and confd_package_repo | length > 0
   tags: get_confd, confd
 
 - name: Create conf directories

--- a/automation/roles/confd/templates/haproxy.toml.j2
+++ b/automation/roles/confd/templates/haproxy.toml.j2
@@ -2,11 +2,7 @@
 prefix = "/{{ patroni_etcd_namespace | default('service') }}/{{ patroni_cluster_name }}"
 src = "haproxy.tmpl"
 dest = "/etc/haproxy/haproxy.cfg"
-{% if haproxy_installation_method == "src" %}
-check_cmd = "/usr/local/sbin/haproxy -c -f {% raw %}{{ .src }}{% endraw %}"
-{% else %}
 check_cmd = "/usr/sbin/haproxy -c -f {% raw %}{{ .src }}{% endraw %}"
-{% endif %}
 reload_cmd = "/bin/systemctl reload haproxy"
 
 keys = [

--- a/automation/roles/etcd/tasks/main.yml
+++ b/automation/roles/etcd/tasks/main.yml
@@ -44,31 +44,8 @@
         - etcd
         - etcdctl
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - etcd_package_repo | length > 0
-    - not ansible_check_mode
-  tags: etcd, etcd_install
-
-- block: # install etcd package from file
-    - name: Extract "etcd" into /tmp
-      ansible.builtin.unarchive:
-        src: "{{ etcd_package_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-
-    - name: Copy "etcd" and "etcdctl" binary files to /usr/local/bin/
-      ansible.builtin.copy:
-        src: "/tmp/{{ etcd_package_file.split('.tar.gz')[0] | basename }}/{{ item }}"
-        dest: /usr/local/bin/
-        mode: u+x,g+x,o+x
-        remote_src: true
-      loop:
-        - etcd
-        - etcdctl
-  when:
-    - installation_method == "file"
-    - etcd_package_file | length > 0
     - not ansible_check_mode
   tags: etcd, etcd_install
 

--- a/automation/roles/haproxy/tasks/main.yml
+++ b/automation/roles/haproxy/tasks/main.yml
@@ -7,81 +7,39 @@
   when: hostvars[groups['postgres_cluster'][0]].ansible_hostname is not defined
 
 # Install HAProxy from rpm/deb packages
-
-# RedHat
-- name: Install HAProxy package
-  ansible.builtin.package:
-    name: haproxy
-    state: present
-  register: package_status
-  until: package_status is success
-  delay: 5
-  retries: 3
-  environment: "{{ proxy_env | default({}) }}"
-  when:
-    - ansible_os_family == "RedHat"
-    - installation_method == "repo"
-    - haproxy_installation_method == "rpm"
-  tags: haproxy, load_balancing
-
-# Debian
-- name: Install HAProxy package
-  ansible.builtin.apt:
-    name: haproxy
-    state: present
-  register: apt_status
-  until: apt_status is success
-  delay: 5
-  retries: 3
-  environment: "{{ proxy_env | default({}) }}"
-  when:
-    - ansible_os_family == "Debian"
-    - installation_method == "repo"
-    - haproxy_installation_method == "deb"
-  tags: haproxy, load_balancing
-
-# from file (rpm/deb packages)
 - block:
-    - name: Copy packages into /tmp
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ item }}"
-        dest: /tmp/
-      loop: "{{ haproxy_package_file }}"
-      register: copy_packages_result
-
-    - name: Install packages
-      ansible.builtin.apt:
-        force_apt_get: true
-        deb: "/tmp/{{ item }}"
-        state: present
-      loop: "{{ haproxy_package_file | map('basename') | list }}"
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "Debian" and copy_packages_result.changed
-
-    - name: Install packages
+    # RedHat
+    - name: Install HAProxy package
       ansible.builtin.package:
-        name: "/tmp/{{ item }}"
+        name: haproxy
         state: present
-      loop: "{{ haproxy_package_file | map('basename') | list }}"
       register: package_status
       until: package_status is success
       delay: 5
       retries: 3
-      when: ansible_os_family == "RedHat" and copy_packages_result.changed
-  when: haproxy_package_file is defined and haproxy_package_file | length > 0
+      environment: "{{ proxy_env | default({}) }}"
+      when:
+        - ansible_os_family == "RedHat"
+        - haproxy_installation_method == "rpm"
+      tags: haproxy, load_balancing
+
+    # Debian
+    - name: Install HAProxy package
+      ansible.builtin.apt:
+        name: haproxy
+        state: present
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      environment: "{{ proxy_env | default({}) }}"
+      when:
+        - ansible_os_family == "Debian"
+        - haproxy_installation_method == "deb"
+  when: installation_method == "packages"
   tags: haproxy, load_balancing
 
 # Build and install HAproxy from source
-- name: Setting facts
-  ansible.builtin.set_fact:
-    target_linux: "{% if haproxy_major is version('2.0', '>=') %}linux-glibc{% else %}linux2628{% endif %}"
-  when: haproxy_installation_method == "src"
-  tags: haproxy, load_balancing
-
-# from repo
 - block:
     - name: "Download HAProxy and lua source files"
       ansible.builtin.get_url:
@@ -112,28 +70,9 @@
         remote_src: true
       when: lua_src_repo | length > 0
       tags: lua
-  when: installation_method == "repo" and haproxy_installation_method == "src"
-  tags: haproxy, load_balancing
-
-# from file
-- block:
-    - name: "Extract HAProxy source files into /tmp"
-      ansible.builtin.unarchive:
-        src: "{{ haproxy_src_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-      when: haproxy_src_file | length > 0
-
-    - name: "Extract lua source files into /tmp"
-      ansible.builtin.unarchive:
-        src: "{{ lua_src_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-      when: lua_src_file | length > 0
-      tags: lua
-  when: installation_method == "file" and haproxy_installation_method == "src"
+  when:
+    - installation_method == "packages"
+    - haproxy_installation_method == "src"
   tags: haproxy, load_balancing
 
 - name: Install the prerequisites packages to compile HAProxy
@@ -184,46 +123,9 @@
       community.general.make:
         chdir: "/tmp/{{ haproxy_src_repo.split('.tar.gz')[0] | basename }}"
         target: install
-  when: installation_method == "repo" and haproxy_installation_method == "src"
-  tags: haproxy, load_balancing
-
-# installation_method: "file"
-- block:
-    - name: Build and install lua (required for haproxy)
-      become: true
-      become_user: root
-      ansible.builtin.shell: "make INSTALL_TOP=/opt/{{ lua_src_file.split('.tar.gz')[0] | basename }} linux install"
-      args:
-        chdir: "/tmp/{{ lua_src_file.split('.tar.gz')[0] | basename }}"
-      tags: lua
-
-    - name: Build HAProxy
-      become: true
-      become_user: root
-      community.general.make:
-        chdir: "/tmp/{{ haproxy_src_file.split('.tar.gz')[0] | basename }}"
-        params:
-          TARGET: "{{ target_linux }}"
-          USE_GETADDRINFO: 1
-          USE_ZLIB: 1
-          USE_REGPARM: 1
-          USE_OPENSSL: 1
-          USE_LIBCRYPT: 1
-          USE_SYSTEMD: 1
-          USE_PCRE: 1
-          USE_NS: 1
-          USE_TFO: 1
-          USE_LUA: 1
-          LUA_INC: "/opt/{{ lua_src_file.split('.tar.gz')[0] | basename }}/include"
-          LUA_LIB: "/opt/{{ lua_src_file.split('.tar.gz')[0] | basename }}/lib"
-
-    - name: Install HAProxy
-      become: true
-      become_user: root
-      community.general.make:
-        chdir: "/tmp/{{ haproxy_src_file.split('.tar.gz')[0] | basename }}"
-        target: install
-  when: installation_method == "file" and haproxy_installation_method == "src"
+  vars:
+    target_linux: "{% if haproxy_major is version('2.0', '>=') %}linux-glibc{% else %}linux2628{% endif %}"
+  when: installation_method == "packages" and haproxy_installation_method == "src"
   tags: haproxy, load_balancing
 
 # Configure
@@ -375,7 +277,7 @@
       environment: "{{ proxy_env | default({}) }}"
       when:
         - ansible_os_family == "RedHat"
-        - installation_method == "repo"
+        - installation_method == "packages"
         - haproxy_installation_method == "rpm"
 
     - name: selinux | set haproxy_connect_any flag to enable tcp connections

--- a/automation/roles/haproxy/tasks/main.yml
+++ b/automation/roles/haproxy/tasks/main.yml
@@ -18,9 +18,7 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when:
-        - ansible_os_family == "RedHat"
-        - haproxy_installation_method == "rpm"
+      when: ansible_os_family == "RedHat"
       tags: haproxy, load_balancing
 
     # Debian
@@ -33,99 +31,8 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when:
-        - ansible_os_family == "Debian"
-        - haproxy_installation_method == "deb"
+      when: ansible_os_family == "Debian"
   when: installation_method == "packages"
-  tags: haproxy, load_balancing
-
-# Build and install HAproxy from source
-- block:
-    - name: "Download HAProxy and lua source files"
-      ansible.builtin.get_url:
-        url: "{{ item }}"
-        dest: /tmp/
-        timeout: 120
-        validate_certs: false
-      loop:
-        - "{{ haproxy_src_repo }}"
-        - "{{ lua_src_repo }}"
-      environment: "{{ proxy_env | default({}) }}"
-
-    - name: "Extract HAProxy source files into /tmp"
-      ansible.builtin.unarchive:
-        src: "/tmp/{{ haproxy_src_repo | basename }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-        remote_src: true
-      when: haproxy_src_repo | length > 0
-
-    - name: "Extract lua source files into /tmp"
-      ansible.builtin.unarchive:
-        src: "/tmp/{{ lua_src_repo | basename }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-        remote_src: true
-      when: lua_src_repo | length > 0
-      tags: lua
-  when:
-    - installation_method == "packages"
-    - haproxy_installation_method == "src"
-  tags: haproxy, load_balancing
-
-- name: Install the prerequisites packages to compile HAProxy
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  loop: "{{ haproxy_compile_requirements | flatten }}"
-  register: package_status
-  until: package_status is success
-  delay: 5
-  retries: 3
-  environment: "{{ proxy_env | default({}) }}"
-  when: haproxy_installation_method == "src"
-  tags: haproxy, haproxy_requirements, load_balancing
-
-- block:
-    - name: Build and install lua (required for haproxy)
-      become: true
-      become_user: root
-      ansible.builtin.shell: "make INSTALL_TOP=/opt/{{ lua_src_repo.split('.tar.gz')[0] | basename }} linux install"
-      args:
-        chdir: "/tmp/{{ lua_src_repo.split('.tar.gz')[0] | basename }}"
-      tags: lua
-
-    - name: Build HAProxy
-      become: true
-      become_user: root
-      community.general.make:
-        chdir: "/tmp/{{ haproxy_src_repo.split('.tar.gz')[0] | basename }}"
-        params:
-          TARGET: "{{ target_linux }}"
-          USE_GETADDRINFO: 1
-          USE_ZLIB: 1
-          USE_REGPARM: 1
-          USE_OPENSSL: 1
-          USE_LIBCRYPT: 1
-          USE_SYSTEMD: 1
-          USE_PCRE: 1
-          USE_NS: 1
-          USE_TFO: 1
-          USE_LUA: 1
-          LUA_INC: "/opt/{{ lua_src_repo.split('.tar.gz')[0] | basename }}/include"
-          LUA_LIB: "/opt/{{ lua_src_repo.split('.tar.gz')[0] | basename }}/lib"
-
-    - name: Install HAProxy
-      become: true
-      become_user: root
-      community.general.make:
-        chdir: "/tmp/{{ haproxy_src_repo.split('.tar.gz')[0] | basename }}"
-        target: install
-  vars:
-    target_linux: "{% if haproxy_major is version('2.0', '>=') %}linux-glibc{% else %}linux2628{% endif %}"
-  when: installation_method == "packages" and haproxy_installation_method == "src"
   tags: haproxy, load_balancing
 
 # Configure
@@ -278,7 +185,6 @@
       when:
         - ansible_os_family == "RedHat"
         - installation_method == "packages"
-        - haproxy_installation_method == "rpm"
 
     - name: selinux | set haproxy_connect_any flag to enable tcp connections
       ansible.posix.seboolean:

--- a/automation/roles/haproxy/templates/haproxy.service.j2
+++ b/automation/roles/haproxy/templates/haproxy.service.j2
@@ -5,15 +5,9 @@ After=network.target
 [Service]
 Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy/haproxy.pid"
 ExecStartPre=/bin/mkdir -p /run/haproxy
-{% if haproxy_installation_method == "src" %}
-ExecStartPre=/usr/local/sbin/haproxy -f $CONFIG -c -q
-ExecStart=/usr/local/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
-ExecReload=/usr/local/sbin/haproxy -f $CONFIG -c -q
-{% else %}
 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
 ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q
-{% endif %}
 ExecReload=/bin/kill -USR2 $MAINPID
 KillMode=mixed
 Restart=always

--- a/automation/roles/packages/tasks/main.yml
+++ b/automation/roles/packages/tasks/main.yml
@@ -1,38 +1,4 @@
 ---
-# Install packages from files
-- block:
-    - name: Copy packages into /tmp
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ item }}"
-        dest: /tmp/
-      loop: "{{ packages_from_file }}"
-      register: copy_packages_result
-
-    - name: Install packages
-      ansible.builtin.apt:
-        force_apt_get: true
-        deb: "/tmp/{{ item }}"
-        state: present
-      loop: "{{ packages_from_file | map('basename') | list }}"
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "Debian" and copy_packages_result.changed
-
-    - name: Install packages
-      ansible.builtin.package:
-        name: "/tmp/{{ item }}"
-        state: present
-      loop: "{{ packages_from_file | map('basename') | list }}"
-      register: package_status
-      until: package_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "RedHat" and copy_packages_result.changed
-  when: packages_from_file is defined and packages_from_file | length > 0
-  tags: install_packages_from_file
-
 # Install packages from repository
 
 # RedHat
@@ -45,7 +11,7 @@
   delay: 5
   retries: 3
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
   environment: "{{ proxy_env | default({}) }}"
   tags: install_packages, install_postgres
@@ -62,7 +28,7 @@
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - system_packages | default('') | length > 0
   tags: install_packages
@@ -75,7 +41,7 @@
     priority: 1100
     state: selected
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - python_version | default('') | length > 1
   tags: install_packages
@@ -88,7 +54,7 @@
     priority: 1100
     state: selected
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - python_version | default('') | length > 1
     - pip_package in system_packages
@@ -106,7 +72,7 @@
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
 
 - name: Install system packages
@@ -120,7 +86,7 @@
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
     - system_packages | default('') | length > 0
   tags: install_packages
@@ -138,7 +104,7 @@
       ansible.builtin.command: "dnf -y -C module disable postgresql"
       when: "'[x] ' not in postgresql_module_result.stdout"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version >= '8'
   ignore_errors: true
@@ -155,7 +121,7 @@
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - postgresql_packages | default('') | length > 0
   tags: install_packages, install_postgres
@@ -183,7 +149,7 @@
         dest: /etc/logrotate.d/postgresql-common
         state: absent
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
   tags: install_postgres
 
@@ -197,7 +163,7 @@
     - name: PostgreSQL | disable appstream module
       ansible.builtin.command: "dnf -y -C module disable postgresql"
       when: "'[x] ' not in postgresql_module_result.stdout"
-  when: installation_method == "repo" and ansible_os_family == "RedHat"
+  when: installation_method == "packages" and ansible_os_family == "RedHat"
   ignore_errors: true
   tags: install_postgres
 
@@ -214,7 +180,7 @@
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - postgresql_packages | default('') | length > 0
   tags: install_packages, install_postgres
@@ -231,7 +197,7 @@
   delay: 5
   retries: 3
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
     - postgresql_packages | default('') | length > 0
   tags: install_packages, install_postgres
@@ -239,7 +205,7 @@
 # Extensions
 - name: Install PostgreSQL Extensions
   ansible.builtin.import_tasks: extensions.yml
-  when: installation_method == "repo"
+  when: installation_method == "packages"
   tags: install_packages, install_postgres, install_extensions
 
 # Install perf (if 'install_perf' is 'true')
@@ -247,3 +213,37 @@
   ansible.builtin.import_tasks: perf.yml
   when: install_perf | bool
   tags: install_packages, install_perf, perf
+
+# Install packages from files (optional)
+- block:
+    - name: Copy packages into /tmp
+      ansible.builtin.copy:
+        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ item }}"
+        dest: /tmp/
+      loop: "{{ packages_from_file }}"
+      register: copy_packages_result
+
+    - name: Install packages
+      ansible.builtin.apt:
+        force_apt_get: true
+        deb: "/tmp/{{ item }}"
+        state: present
+      loop: "{{ packages_from_file | map('basename') | list }}"
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      when: ansible_os_family == "Debian" and copy_packages_result.changed
+
+    - name: Install packages
+      ansible.builtin.dnf:
+        name: "/tmp/{{ item }}"
+        state: present
+      loop: "{{ packages_from_file | map('basename') | list }}"
+      register: package_status
+      until: package_status is success
+      delay: 5
+      retries: 3
+      when: ansible_os_family == "RedHat" and copy_packages_result.changed
+  when: packages_from_file is defined and packages_from_file | length > 0
+  tags: install_packages_from_file

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -12,7 +12,7 @@
   tags: patroni, patroni_install, pip
 
 # Patroni install
-- block: # installation_method: "repo" and patroni_installation_method: "pip"
+- block: # installation_method: "packages" and patroni_installation_method: "pip"
     - name: Install setuptools
       ansible.builtin.pip:
         name: setuptools<66.0.0 # https://github.com/pypa/setuptools/issues/3772
@@ -71,7 +71,7 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length < 1 and patroni_install_version != "latest"
-  when: installation_method == "repo" and patroni_installation_method == "pip"
+  when: installation_method == "packages" and patroni_installation_method == "pip"
   environment: "{{ proxy_env | default({}) }}"
   tags: patroni, patroni_install
 
@@ -117,51 +117,10 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length > 0
-  when: installation_method == "repo" and patroni_installation_method == "pip"
+  when: installation_method == "packages" and patroni_installation_method == "pip"
   tags: patroni, patroni_install
 
-- block: # installation_method: "file" and patroni_installation_method: "pip"
-    - name: Copy patroni requirements
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ item }}"
-        dest: /tmp/
-      loop: "{{ patroni_pip_requirements_file }}"
-      when: patroni_pip_requirements_file | length > 0
-
-    - name: Copy patroni package
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ item }}"
-        dest: /tmp/
-      loop: "{{ patroni_pip_package_file }}"
-      when: patroni_pip_package_file | length > 0
-
-    - name: Install requirements
-      ansible.builtin.pip:
-        name: "file:///tmp/{{ item }}"
-        executable: pip3
-        extra_args: "--no-index --find-links=file:///tmp --ignore-installed"
-        umask: "0022"
-      loop: "{{ patroni_pip_requirements_file | map('basename') | list }}"
-      environment:
-        PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
-        PIP_BREAK_SYSTEM_PACKAGES: "1"
-      when: patroni_pip_requirements_file | length > 0
-
-    - name: Install patroni
-      ansible.builtin.pip:
-        name: "file:///tmp/{{ item }}"
-        executable: pip3
-        extra_args: "--no-index --find-links=file:///tmp --ignore-installed"
-        umask: "0022"
-      loop: "{{ patroni_pip_package_file | map('basename') | list }}"
-      environment:
-        PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
-        PIP_BREAK_SYSTEM_PACKAGES: "1"
-      when: patroni_pip_package_file | length > 0
-  when: installation_method == "file" and patroni_installation_method == "pip"
-  tags: patroni, patroni_install
-
-- block: # installation_method: "repo" and patroni_installation_method: "rpm/deb"
+- block: # installation_method: "packages" and patroni_installation_method: "rpm/deb"
     # Debian
     - name: Install patroni package
       ansible.builtin.apt:
@@ -230,47 +189,7 @@
       retries: 3
       when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
-  tags: patroni, patroni_install
-
-# installation_method: "file" and patroni_installation_method: "rpm/deb"
-- block:
-    # Debian
-    - name: Copy patroni deb package into /tmp
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ patroni_deb_package_file }}"
-        dest: /tmp/
-      when: ansible_os_family == "Debian"
-
-    - name: Install patroni from deb package
-      ansible.builtin.apt:
-        force_apt_get: true
-        deb: "/tmp/{{ patroni_deb_package_file | basename }}"
-        state: present
-      register: deb_package_file_status
-      until: deb_package_file_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "Debian"
-
-    # RedHat
-    - name: Copy patroni rpm package into /tmp
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ patroni_rpm_package_file }}"
-        dest: /tmp/
-      when: ansible_os_family == "RedHat"
-
-    - name: Install patroni from rpm package
-      ansible.builtin.dnf:
-        name: "/tmp/{{ patroni_rpm_package_file | basename }}"
-        state: present
-        disable_gpg_check: true
-      register: rpm_package_file_status
-      until: rpm_package_file_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "RedHat"
-  when: installation_method == "file" and (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
+  when: installation_method == "packages" and (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
   tags: patroni, patroni_install
 
 # Patroni configure

--- a/automation/roles/patroni/tasks/pip.yml
+++ b/automation/roles/patroni/tasks/pip.yml
@@ -4,7 +4,7 @@
 # A future version of pip will drop support for Python 2.7.
 # Installing latest version pip3 for python3
 
-# install pip package from repo (installation_method: "repo")
+# install pip package from repo (installation_method: "packages")
 - block: # with get-pip.py
     - name: pip | get-pip.py
       ansible.builtin.get_url:
@@ -36,7 +36,7 @@
         chdir: /tmp/
       when: get_pip_result.changed
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and
+  when: installation_method == "packages" and
     patroni_installation_method == "pip" and
     pip_package_repo is search("get-pip.py")
   tags: pip_install, pip
@@ -65,25 +65,5 @@
       args:
         chdir: "/tmp/{{ pip_package_repo.split('.tar.gz')[0] | basename }}"
       when: pip_package_result.changed
-  when: installation_method == "repo" and
-    pip_package_repo is search("tar.gz")
-  tags: pip_install, pip
-
-# install pip package from file (installation_method: "file")
-- block:
-    - name: pip | extract pip package into /tmp
-      ansible.builtin.unarchive:
-        src: "{{ pip_package_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-      register: pip_package_result
-
-    - name: pip | install pip
-      ansible.builtin.command: python3 setup.py install
-      args:
-        chdir: "/tmp/{{ pip_package_file.split('.tar.gz')[0] | basename }}"
-      when: pip_package_result.changed
-  when: installation_method == "file" and
-    pip_package_file | length > 0
+  when: installation_method == "packages" and pip_package_repo is search("tar.gz")
   tags: pip_install, pip

--- a/automation/roles/pg_probackup/tasks/main.yml
+++ b/automation/roles/pg_probackup/tasks/main.yml
@@ -44,7 +44,7 @@
       retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
     - pg_probackup_install_from_postgrespro_repo|bool
   tags: pg_probackup, pg_probackup_repo, pg_probackup_install
@@ -101,7 +101,7 @@
       retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - pg_probackup_install_from_postgrespro_repo|bool
   tags: pg_probackup, pg_probackup_repo, pg_probackup_install

--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -42,7 +42,7 @@
       retries: 3
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "Debian"
     - pgbackrest_install_from_pgdg_repo|bool
   tags: pgbackrest, pgbackrest_repo, pgbackrest_install
@@ -69,7 +69,7 @@
       ansible.builtin.command: dnf clean all
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - ansible_os_family == "RedHat"
     - pgbackrest_install_from_pgdg_repo|bool
   tags: pgbackrest, pgbackrest_repo, pgbackrest_install

--- a/automation/roles/timezone/tasks/main.yml
+++ b/automation/roles/timezone/tasks/main.yml
@@ -7,7 +7,7 @@
         name: tzdata
         state: present
       environment: "{{ proxy_env | default({}) }}"
-      when: installation_method == "repo"
+      when: installation_method == "packages"
 
     - name: Set timezone to "{{ timezone }}"
       become: true

--- a/automation/roles/update/tasks/patroni.yml
+++ b/automation/roles/update/tasks/patroni.yml
@@ -14,7 +14,7 @@
       register: update_patroni_package_pip
   ignore_errors: true
   environment: "{{ proxy_env | default({}) }}"
-  when: installation_method == "repo" and patroni_installation_method == "pip"
+  when: installation_method == "packages" and patroni_installation_method == "pip"
 
 # patroni_installation_method: "rpm/deb"
 - block:
@@ -86,7 +86,7 @@
   ignore_errors: true
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
 
 # Set flag if any update failed

--- a/automation/roles/vip_manager/tasks/main.yml
+++ b/automation/roles/vip_manager/tasks/main.yml
@@ -32,42 +32,8 @@
       retries: 3
       when: ansible_os_family == "RedHat"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - vip_manager_package_repo | length > 0
-    - not ansible_check_mode
-    - not postgresql_cluster_maintenance | default(false) | bool
-  tags: vip, vip_manager, vip_manager_install
-
-- block: # install vip-manager package from file
-    - name: Copy vip-manager package into /tmp
-      ansible.builtin.copy:
-        src: "{{ files_dir | default(playbook_dir ~ '/files') }}/{{ vip_manager_package_file }}"
-        dest: /tmp/
-
-    - name: Install vip-manager
-      ansible.builtin.apt:
-        force_apt_get: true
-        deb: "/tmp/{{ vip_manager_package_file | basename }}"
-        state: present
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "Debian"
-
-    - name: Install vip-manager
-      ansible.builtin.package:
-        name: "/tmp/{{ vip_manager_package_file | basename }}"
-        state: present
-        disable_gpg_check: true
-      register: package_status
-      until: package_status is success
-      delay: 5
-      retries: 3
-      when: ansible_os_family == "RedHat"
-  when:
-    - installation_method == "file"
-    - vip_manager_package_file | length > 0
     - not ansible_check_mode
     - not postgresql_cluster_maintenance | default(false) | bool
   tags: vip, vip_manager, vip_manager_install

--- a/automation/roles/wal_g/tasks/main.yml
+++ b/automation/roles/wal_g/tasks/main.yml
@@ -64,7 +64,7 @@
         mode: u+x,g+x,o+x
         remote_src: true
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - wal_g_installation_method == "binary"
     - wal_g_version is version('1.0', '>=')
     - (wal_g_installed_version.stderr is search("command not found") or wal_g_installed_version.stdout != wal_g_version)
@@ -188,7 +188,7 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
   environment: "{{ proxy_env | default({}) }}"
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - (wal_g_installation_method == "src" or (ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'))
     - wal_g_version is version('1.0', '>=')
     - (wal_g_installed_version.stderr is search("command not found") or wal_g_installed_version.stdout != wal_g_version)
@@ -222,60 +222,10 @@
         mode: u+x,g+x,o+x
         remote_src: true
   when:
-    - installation_method == "repo"
+    - installation_method == "packages"
     - wal_g_installation_method == "binary"
     - wal_g_version is version('0.2.19', '<=')
     - (wal_g_installed_version.stderr is search("command not found") or wal_g_installed_version.stdout != wal_g_version)
-  tags: wal-g, wal_g, wal_g_install
-
-# installation_method == "file"
-
-# A precompiled binary (package in tar.gz)
-- block:
-    - name: "Extract WAL-G archive {{ wal_g_package_file }} into /tmp"
-      ansible.builtin.unarchive:
-        src: "{{ wal_g_package_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-
-    - name: Copy WAL-G binary file to "{{ wal_g_path.split(' ')[0] }}"
-      ansible.builtin.copy:
-        src: "/tmp/{{ wal_g_package_file.split('.tar.gz')[0] | basename }}"
-        dest: "{{ wal_g_path.split(' ')[0] }}"
-        mode: u+x,g+x,o+x
-        remote_src: true
-  check_mode: false
-  when:
-    - installation_method == "file"
-    - wal_g_version is version('1.0', '>=')
-    - (wal_g_installed_version.stderr is search("command not found") or
-      wal_g_installed_version.stdout != wal_g_version)
-    - (wal_g_package_file is defined and wal_g_package_file | length > 0)
-  tags: wal-g, wal_g, wal_g_install
-
-# older versions of WAL-G (for compatibility)
-- block:
-    - name: "Extract WAL-G archive {{ wal_g_package_file }} into /tmp"
-      ansible.builtin.unarchive:
-        src: "{{ wal_g_package_file }}"
-        dest: /tmp/
-        extra_opts:
-          - --no-same-owner
-
-    - name: Copy WAL-G binary file to "{{ wal_g_path.split(' ')[0] }}"
-      ansible.builtin.copy:
-        src: "/tmp/wal-g"
-        dest: "{{ wal_g_path.split(' ')[0] }}"
-        mode: u+x,g+x,o+x
-        remote_src: true
-  check_mode: false
-  when:
-    - installation_method == "file"
-    - wal_g_version is version('0.2.19', '<=')
-    - (wal_g_installed_version.stderr is search("command not found") or
-      wal_g_installed_version.stdout != wal_g_version)
-    - wal_g_package_file == "wal-g.linux-amd64.tar.gz"
   tags: wal-g, wal_g, wal_g_install
 
 # Ensure the WAL_G_PREFETCH directory is created if configured


### PR DESCRIPTION
We have removed the `installation_method: "file"` option, as it was rarely used and added unnecessary maintenance burden to the codebase.

Instead, we kept support for packages_from_file, which allows specifying custom .deb or .rpm packages located in the files/ directory. This provides a flexible option for advanced offline setups, without introducing complexity to the main installation flow.

For typical offline environments, it’s now expected that users either:
- Configure a corporate proxy via the proxy_env variable, or
- Use a private package repository and preload required packages there.

This change simplifies the code while still supporting installation in air-gapped environments when necessary.