### PR TITLE
PgBackrest: Create a repo directory for the posix type only

### DIFF
--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -106,7 +106,10 @@
         group: postgres
         mode: "0750"
       loop: "{{ pgbackrest_conf.global }}"
-      when: item.option == 'repo1-path' and pgbackrest_repo_host | length < 1
+      when:
+        - item.option == 'repo1-path'
+        - pgbackrest_repo_type | lower == 'posix'
+        - pgbackrest_repo_host | length < 1
       loop_control:
         label: "{{ item.value }}"
 


### PR DESCRIPTION
Creating a directory is unnecessary if the repository is not local (posix), such as when using an S3-based repository.