### PR TITLE
Avoid using "hosts: all" in the deploy_pgcluster playbook

### DIFF
--- a/automation/galaxy.yml
+++ b/automation/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: vitabaks
 name: autobase
-version: 2.2.1
+version: 2.2.2
 
 readme: README.md
 

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -21,8 +21,8 @@
       when: cloud_provider | default('') | length > 0
       tags: always
 
-- name: vitabaks.autobase.deploy_pgcluster | Perform pre-checks
-  hosts: all
+- name: vitabaks.autobase.deploy_pgcluster | Perform pre-checks and preparation
+  hosts: "etcd_cluster:consul_instances:balancers:postgres_cluster"
   become: true
   become_method: sudo
   gather_facts: true


### PR DESCRIPTION
Explicitly list the host groups instead of using "hosts: all".

This is especially important for users consuming Autobase automation as an Ansible collection installed via ansible-galaxy. 