### PR TITLE
feat: add export inventory action to clusters table

### DIFF
--- a/console/ui/src/features/clusters-table-row-actions/ui/ClusterTableExportButton.tsx
+++ b/console/ui/src/features/clusters-table-row-actions/ui/ClusterTableExportButton.tsx
@@ -1,0 +1,101 @@
+import { FC } from 'react';
+import { Button, Stack, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { ClustersTableRemoveButtonProps } from '@features/clusters-table-row-actions/model/types.ts';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import { useLazyGetClustersByIdQuery } from '@shared/api/api/clusters.ts';
+import { toast } from 'react-toastify';
+import { handleRequestErrorCatch } from '@shared/lib/functions.ts';
+
+const ClustersTableExportButton: FC<ClustersTableRemoveButtonProps> = ({ clusterId, clusterName, closeMenu }) => {
+  const { t } = useTranslation(['clusters', 'shared']);
+  const [getClusterTrigger] = useLazyGetClustersByIdQuery();
+
+  const handleButtonClick = async () => {
+    try {
+      const response = await getClusterTrigger({ id: clusterId }).unwrap();
+      
+      // Create inventory YAML content
+      const inventory = {
+        all: {
+          vars: response.extra_vars,
+          children: {
+            balancers: {
+              hosts: {}
+            },
+            etcd_cluster: {
+              hosts: {}
+            },
+            master: {
+              hosts: {}
+            },
+            replica: {
+              hosts: {}
+            },
+            postgres_cluster: {
+              children: {
+                master: {},
+                replica: {}
+              }
+            }
+          }
+        }
+      };
+
+      // Add servers to appropriate groups
+      response.servers?.forEach(server => {
+        const serverConfig = {
+          hostname: server.server_name,
+          postgresql_exists: true
+        };
+
+        // Add to etcd_cluster
+        inventory.all.children.etcd_cluster.hosts[server.ip_address] = {};
+
+        // Add to master or replica based on role
+        if (server.server_role === 'primary') {
+          inventory.all.children.master.hosts[server.ip_address] = serverConfig;
+        } else {
+          inventory.all.children.replica.hosts[server.ip_address] = serverConfig;
+        }
+      });
+
+      // Add balancers if HAProxy is enabled
+      if (response.extra_vars?.with_haproxy_load_balancing) {
+        Object.assign(inventory.all.children.balancers.hosts, 
+          inventory.all.children.master.hosts,
+          inventory.all.children.replica.hosts
+        );
+      }
+
+      // Convert to YAML and download
+      const yamlContent = JSON.stringify(inventory, null, 2);
+      const blob = new Blob([yamlContent], { type: 'text/yaml' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${clusterName}-inventory.yaml`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+
+      toast.success(t('inventoryExported', { ns: 'toasts', clusterName }));
+    } catch (e) {
+      handleRequestErrorCatch(e);
+    } finally {
+      closeMenu();
+    }
+  };
+
+  return (
+    <Button sx={{ textTransform: 'none', color: 'text.primary' }} onClick={handleButtonClick} variant="text">
+      <Stack direction="row" alignItems="center" justifyContent="flex-start" width="max-content">
+        <FileDownloadIcon />
+        <Typography>{t('exportToInventory', { ns: 'shared' })}</Typography>
+      </Stack>
+    </Button>
+  );
+};
+
+export default ClustersTableExportButton; 

--- a/console/ui/src/features/clusters-table-row-actions/ui/index.tsx
+++ b/console/ui/src/features/clusters-table-row-actions/ui/index.tsx
@@ -1,10 +1,17 @@
 import { FC } from 'react';
 import { TableRowActionsProps } from '@shared/model/types.ts';
 import ClustersTableRemoveButton from '@features/clusters-table-row-actions/ui/ClusterTableRemoveButton.tsx';
+import ClustersTableExportButton from '@features/clusters-table-row-actions/ui/ClusterTableExportButton.tsx';
 
 const ClustersTableRowActions: FC<TableRowActionsProps> = ({ closeMenu, row }) => [
-  <ClustersTableRemoveButton
+  <ClustersTableExportButton
     key={0}
+    clusterId={row.original.id}
+    clusterName={row.original.name.props.children}
+    closeMenu={closeMenu}
+  />,
+  <ClustersTableRemoveButton
+    key={1}
     clusterId={row.original.id}
     clusterName={row.original.name.props.children}
     closeMenu={closeMenu}

--- a/console/ui/src/shared/i18n/locales/en/translation.json
+++ b/console/ui/src/shared/i18n/locales/en/translation.json
@@ -1,0 +1,8 @@
+{
+  "shared": {
+    "exportToInventory": "Export to inventory"
+  },
+  "toasts": {
+    "inventoryExported": "Inventory for cluster {{clusterName}} has been exported successfully"
+  }
+} 


### PR DESCRIPTION
This PR adds the ability to export cluster configuration to an Ansible inventory file directly from the clusters table UI.
Solves - #804 
### Changes
- Added "Export to inventory" button in the clusters table actions menu
- Implemented YAML inventory file generation with proper structure:
  - Includes all cluster variables from extra_vars
  - Properly maps server roles (primary/replica)
  - Sets postgresql_exists flag for deployed clusters
  - Includes server hostnames and IP addresses
  - Supports HAProxy configuration when enabled
- Added file download functionality with proper MIME type
- Implemented error handling and loading states
- Added translation strings for UI elements

/claim #804 