### PR TITLE
remove_cluster: Run stanza-delete on repo-host

### DIFF
--- a/automation/playbooks/remove_cluster.yml
+++ b/automation/playbooks/remove_cluster.yml
@@ -1,6 +1,6 @@
 ---
 - name: vitabaks.autobase.remove_cluster | Remove PostgreSQL HA Cluster
-  hosts: postgres_cluster
+  hosts: postgres_cluster:pgbackrest
   become: true
   gather_facts: true
   tasks:
@@ -40,18 +40,22 @@
               {{ default_postgresql_data_dir }}\
               {% endif %}"
       ignore_errors: true
-      when: remove_postgres | default(false) | bool
+      when: remove_postgres | default(false) | bool and inventory_hostname in groups['postgres_cluster']
 
     - block:
         - name: Run pgBackRest stop
           become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ stanza_name }} stop --force"
+          register: pgbackrest_stop_result
+          when: ('pgbackrest' in groups and groups['pgbackrest'] | length > 0 and inventory_hostname in groups['pgbackrest']) or
+            (('pgbackrest' not in groups or groups['pgbackrest'] | length == 0) and inventory_hostname == groups['postgres_cluster'][0])
 
         - name: Delete pgBackRest stanza
           become: true
           become_user: postgres
-          ansible.builtin.command: "pgbackrest --stanza={{ stanza_name }} stanza-delete"
+          ansible.builtin.command: "pgbackrest --stanza={{ stanza_name }} stanza-delete --force"
+          when: pgbackrest_stop_result is defined and pgbackrest_stop_result is changed
 
         - name: Delete pgBackRest cron job
           ansible.builtin.file:


### PR DESCRIPTION
Run stanza-delete on pgbackrest repo-host (if defined), or on the first postgres node if not.

Example:

```
PLAY [vitabaks.autobase.remove_cluster | Remove PostgreSQL HA Cluster] *********
...
TASK [Run pgBackRest stop] *****************************************************
changed: [pgbackrest]

TASK [Delete pgBackRest stanza] ************************************************
changed: [pgbackrest]

TASK [Delete pgBackRest cron job] **********************************************
ok: [pgnode03] => (item=/etc/cron.d/pgbackrest-test-pgcluster)
ok: [pgnode02] => (item=/etc/cron.d/pgbackrest-test-pgcluster)
ok: [pgnode01] => (item=/etc/cron.d/pgbackrest-test-pgcluster)
changed: [pgbackrest] => (item=/etc/cron.d/pgbackrest-test-pgcluster)
...
```

- stop and delete tasks performed on pgbackrest host