### PR TITLE
feat: added chrony

### DIFF
--- a/automation/playbooks/add_pgnode.yml
+++ b/automation/playbooks/add_pgnode.yml
@@ -182,6 +182,7 @@
     - role: vitabaks.autobase.locales
     - role: vitabaks.autobase.timezone
     - role: vitabaks.autobase.ntp
+    - role: vitabaks.autobase.chrony
     - role: vitabaks.autobase.copy
     - role: vitabaks.autobase.cron
 

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -158,6 +158,7 @@
     - role: vitabaks.autobase.io_scheduler
     - role: vitabaks.autobase.locales
     - role: vitabaks.autobase.ntp
+    - role: vitabaks.autobase.chrony
     - role: vitabaks.autobase.ssh_keys
     - role: vitabaks.autobase.copy
     - role: vitabaks.autobase.pgpass

--- a/automation/playbooks/consul_cluster.yml
+++ b/automation/playbooks/consul_cluster.yml
@@ -148,5 +148,6 @@
     - role: vitabaks.autobase.etc_hosts
     - role: vitabaks.autobase.timezone
     - role: vitabaks.autobase.ntp
+    - role: vitabaks.autobase.chrony
 
     - role: vitabaks.autobase.consul

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -267,6 +267,7 @@
     - role: vitabaks.autobase.locales
     - role: vitabaks.autobase.timezone
     - role: vitabaks.autobase.ntp
+    - role: vitabaks.autobase.chrony
     - role: vitabaks.autobase.ssh_keys
     - role: vitabaks.autobase.copy
 

--- a/automation/playbooks/etcd_cluster.yml
+++ b/automation/playbooks/etcd_cluster.yml
@@ -70,5 +70,6 @@
     - role: vitabaks.autobase.etc_hosts
     - role: vitabaks.autobase.timezone
     - role: vitabaks.autobase.ntp
+    - role: vitabaks.autobase.chrony
 
     - role: vitabaks.autobase.etcd

--- a/automation/roles/chrony/README.md
+++ b/automation/roles/chrony/README.md
@@ -1,0 +1,1 @@
+# Ansible Role: chrony

--- a/automation/roles/chrony/handlers/main.yml
+++ b/automation/roles/chrony/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Restart chrony service
+  ansible.builtin.systemd:
+    name: chrony
+    enabled: true
+    state: restarted
+  listen: "restart chrony"
+
+- name: Restart chronyd service
+  ansible.builtin.systemd:
+    name: chronyd
+    enabled: true
+    state: restarted
+  listen: "restart chronyd"
+
+...

--- a/automation/roles/chrony/meta/main.yml
+++ b/automation/roles/chrony/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: vitabaks.autobase.common

--- a/automation/roles/chrony/tasks/main.yml
+++ b/automation/roles/chrony/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+
+- block:
+    - name: Stop and disable systemd-timesyncd service
+      ansible.builtin.systemd:
+        name: systemd-timesyncd
+        enabled: false
+        state: stopped
+      failed_when: false
+      tags: ntp_cleanup
+
+    - name: Remove NTP package if installed
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - ntp
+        - ntpd
+        - ntpdate
+        - ntpsec
+        - openntpd
+      when: ansible_os_family in ["Debian", "RedHat"]
+      tags: ntp_cleanup
+
+    - name: Install chrony package
+      ansible.builtin.package:
+        name: chrony
+        state: present
+      register: package_status
+      until: package_status is success
+      delay: 5
+      retries: 3
+      environment: "{{ proxy_env | default({}) }}"
+      tags: chrony_install
+
+    - name: Ensure chrony service is enabled and started
+      ansible.builtin.systemd:
+        name: chrony
+        enabled: true
+        state: started
+      tags: chrony_install
+
+    - name: Copy the chrony.conf template file
+      ansible.builtin.template:
+        src: chrony.conf.j2
+        dest: /etc/chrony/chrony.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: "restart chrony"
+      tags: chrony_conf
+
+  when: chrony_enabled is defined and chrony_enabled | bool
+  tags: chrony
+
+...

--- a/automation/roles/chrony/templates/chrony.conf.j2
+++ b/automation/roles/chrony/templates/chrony.conf.j2
@@ -1,0 +1,82 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+{% if ntp_servers is defined and ntp_servers | length > 0 %}
+{% for item in ntp_servers %}
+server {{ item }} iburst
+{% endfor %}
+{% else %}
+# Default fallback NTP servers if none specified
+pool ntp.ubuntu.com iburst maxsources 4
+pool 0.ubuntu.pool.ntp.org iburst maxsources 1
+pool 1.ubuntu.pool.ntp.org iburst maxsources 1
+pool 2.ubuntu.pool.ntp.org iburst maxsources 2
+{% endif %}
+
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+{% if chrony_enable_logging | default(false) %}
+log tracking measurements statistics
+{% else %}
+#log tracking measurements statistics
+{% endif %}
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew {{ chrony_maxupdateskew | default('100.0') }}
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can't be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+#makestep 1 -1
+makestep {{ chrony_makestep_threshold | default('1') }} {{ chrony_makestep_limit | default('-1') }}
+
+# Maximum distance to accept time sources
+#maxdistance 1000000000
+maxdistance {{ chrony_maxdistance | default('1000000000') }}
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+#leapsectz right/UTC
+{% if chrony_leapsectz | default(true) %}
+leapsectz right/UTC
+{% endif %}
+
+# Allow NTP client access from local network
+{% if chrony_allow_networks is defined and chrony_allow_networks | length > 0 %}
+{% for network in chrony_allow_networks %}
+allow {{ network }}
+{% endfor %}
+{% endif %}
+
+# Minimum sources for better reliability in DB clusters
+{% if chrony_minsources is defined %}
+minsources {{ chrony_minsources }}
+{% endif %}

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -792,7 +792,20 @@ etc_hosts: []
 #  - "10.128.64.143 pgbackrest.minio.local minio.local s3.eu-west-3.amazonaws.com"  # example (MinIO)
 #  - ""
 
+# Only one of ntp_enabled or chrony_enabled must be true
 ntp_enabled: false # or 'true' if you want to install and configure the ntp service
+chrony_enabled: false
+chrony_enable_logging: false
+chrony_maxupdateskew: "100.0"
+chrony_makestep_threshold: "1"
+chrony_makestep_limit: "-1"
+chrony_maxdistance: "1000000000"
+chrony_leapsectz: true
+chrony_minsources: 2
+chrony_allow_networks:
+#  - "10.0.0.0/8"
+#  - "172.16.0.0/24"
+#  - "192.168.0.0/16"
 ntp_servers: []
 #  - "10.128.64.44"
 #  - "10.128.64.45"

--- a/automation/tags.md
+++ b/automation/tags.md
@@ -23,6 +23,9 @@
 - ntp
 - - ntp_install
 - - ntp_conf
+- chrony
+- - chrony_install
+- - chrony_conf
 - ssh_keys
 - fetch_files
 - copy_files


### PR DESCRIPTION
## Add Chrony NTP service support

### Description
Added support for Chrony service configuration and management.

### Changes
- Added Chrony installation and configuration tasks
- Implemented Chrony service management (start, enable, restart)

### Motivation
Chrony provides better accuracy and faster synchronization compared to traditional NTP, especially in virtualized environments and systems that frequently suspend/resume.

### Type of Change
- [x] New feature

### Testing
- [] Tested on CentOS/RHEL
- [x] Tested on Ubuntu/Debian
- [x] Verified service starts correctly
- [x] Confirmed time synchronization works