### PR TITLE
fix: `config_pgcluster` check_mode 

### DIFF
--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -33,6 +33,7 @@
   environment: "{{ proxy_env | default({}) }}"
   when: installation_method == "packages" and ansible_os_family == "Debian"
   tags: add_repo
+  check_mode: false
 
 - block: # RedHat/CentOS
     - name: Add repository GPG key
@@ -161,6 +162,7 @@
   environment: "{{ proxy_env | default({}) }}"
   when: installation_method == "packages" and ansible_os_family == "RedHat"
   tags: add_repo
+  check_mode: false
 
 - name: Extensions repository
   ansible.builtin.import_tasks: extensions.yml

--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -21,3 +21,4 @@
     - postgresql_databases | default('') | length > 0
     - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_databases
+  check_mode: false


### PR DESCRIPTION
`config_pgcluster` can't currently be executed in check mode as some tasks error out when in such and `check_mode: false` must be used to not fail at these.

Tested with Galaxy release 2.2.3.