### PR TITLE
fix: robustify private interface detection

### DIFF
--- a/automation/molecule/default/verify.yml
+++ b/automation/molecule/default/verify.yml
@@ -15,7 +15,25 @@
     # Define bind_address for each host (first private IPv4), unless set in inventory.
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
   tasks:

--- a/automation/playbooks/add_balancer.yml
+++ b/automation/playbooks/add_balancer.yml
@@ -35,7 +35,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: "[Pre-Check] Check if there is a node with new_node set to true"

--- a/automation/playbooks/add_pgnode.yml
+++ b/automation/playbooks/add_pgnode.yml
@@ -36,7 +36,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: Set maintenance variable

--- a/automation/playbooks/balancers.yml
+++ b/automation/playbooks/balancers.yml
@@ -17,7 +17,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: Update apt cache

--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -37,7 +37,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: "[Prepare] Set maintenance variable"

--- a/automation/playbooks/consul_cluster.yml
+++ b/automation/playbooks/consul_cluster.yml
@@ -16,7 +16,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: Check if the consul role requirements (ansible.utils) are installed

--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -57,10 +57,28 @@
           - network
       when: ansible_all_ipv4_addresses is not defined
 
-    # Define bind_address for each host (first private IPv4), unless set in inventory.
+    # Define bind_address for each host (first private IPv4, excluding Docker interfaces), unless set in inventory.
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     # Print system information

--- a/automation/playbooks/etcd_cluster.yml
+++ b/automation/playbooks/etcd_cluster.yml
@@ -15,7 +15,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: Update apt cache

--- a/automation/playbooks/pg_upgrade.yml
+++ b/automation/playbooks/pg_upgrade.yml
@@ -16,7 +16,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: "[Prepare] Get Patroni Cluster Leader Node"

--- a/automation/playbooks/pg_upgrade_rollback.yml
+++ b/automation/playbooks/pg_upgrade_rollback.yml
@@ -18,7 +18,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'

--- a/automation/playbooks/update_pgcluster.yml
+++ b/automation/playbooks/update_pgcluster.yml
@@ -14,7 +14,25 @@
 
     - name: Expose bind_address as facts
       ansible.builtin.set_fact:
-        bind_address: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | first }}"
+        bind_address: >-
+          {{
+            (ansible_interfaces 
+            | reject('match', '^lo$') 
+            | reject('match', '^docker.*') 
+            | reject('match', '^br-.*') 
+            | reject('match', '^veth.*') 
+            | reject('match', '.*_gwbridge$') 
+            | map('extract', ansible_facts) 
+            | selectattr('ipv4', 'defined') 
+            | map(attribute='ipv4.address') 
+            | select('ansible.utils.ipaddr', 'private') 
+            | list)[0] | default(
+              ansible_all_ipv4_addresses 
+              | ansible.utils.ipaddr('private') 
+              | reject('ansible.utils.ipaddr', '172.17.0.0/12') 
+              | first
+            )
+          }}
       when: bind_address is not defined
 
     - name: "[Prepare] Get Patroni Cluster Leader Node"


### PR DESCRIPTION
The current logic simply takes the first private interface returned on a node as its address.
This might not always be the default private network interface but can also be a non-functional one or the default docker gateway.

This change makes the detection logic more robust and filters out common interface names which shouldn't be set as the default bind address.

As this task appears quite often across playbooks, it might be worth executing it (once) in a top-level role which always runs?