### PR TITLE
Console (UI): Fix the alignment of the cloud provider icon

### DIFF
--- a/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
+++ b/console/ui/src/widgets/cluster-summary/lib/hooks.tsx
@@ -36,7 +36,7 @@ const useGetCloudProviderConfig = () => {
         title: t('cloud'),
         children: (
           <Stack direction={'row'} spacing={1} alignItems="center">
-            <Icon fontSize="large">
+            <Icon fontSize="large" sx={{ display: 'flex', alignItems: 'center' }}>
               <img
                 src={data[CLUSTER_FORM_FIELD_NAMES.PROVIDER]?.icon}
                 alt={data[CLUSTER_FORM_FIELD_NAMES.PROVIDER]?.description?.[0]}


### PR DESCRIPTION
Fix the alignment of the cloud provider icon in the summary.

Before:
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/e8cf4aeb-bb6b-49cc-bf99-cf3ee0d98974" />

After:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/696833e0-8f00-498f-a711-36d680d3ec1f" />
