### PR TITLE
fix: add `pgdg_architecture_map` to pgbackrest role

### DIFF
--- a/automation/roles/pgbackrest/defaults/main.yml
+++ b/automation/roles/pgbackrest/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 pgdg_architecture_map:
   amd64: x86_64
   x86_64: x86_64

--- a/automation/roles/pgbackrest/defaults/main.yml
+++ b/automation/roles/pgbackrest/defaults/main.yml
@@ -1,0 +1,4 @@
+pgdg_architecture_map:
+  amd64: x86_64
+  x86_64: x86_64
+  aarch64: aarch64


### PR DESCRIPTION
Required when `pgbackrest_install: true` in `config_pgcluster` to resolve the architecture map within the role.

```
TASK [vitabaks.autobase.pgbackrest : Get pgdg-redhat-repo-latest.noarch.rpm] *******************************************************************************************************
fatal: [10.11.1.1]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'pgdg_architecture_map' is undefined\n\nThe error appears to be in '/Users/pjs/git/codefloe.com/codefloe/infrastructure-as-code/collections/ansible_collections/vitabaks/autobase/roles/pgbackrest/tasks/main.yml': line 60, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    # RedHat pgdg repo\n    - name: Get pgdg-redhat-repo-latest.noarch.rpm\n      ^ here\n"}
fatal: [10.11.1.2]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'pgdg_architecture_map' is undefined\n\nThe error appears to be in '/Users/pjs/git/codefloe.com/codefloe/infrastructure-as-code/collections/ansible_collections/vitabaks/autobase/roles/pgbackrest/tasks/main.yml': line 60, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    # RedHat pgdg repo\n    - name: Get pgdg-redhat-repo-latest.noarch.rpm\n      ^ here\n"}
fatal: [10.11.1.3]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'pgdg_architecture_map' is undefined\n\nThe error appears to be in '/Users/pjs/git/codefloe.com/codefloe/infrastructure-as-code/collections/ansible_collections/vitabaks/autobase/roles/pgbackrest/tasks/main.yml': line 60, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    # RedHat pgdg repo\n    - name: Get pgdg-redhat-repo-latest.noarch.rpm\n      ^ here\n"}
```

Tested with current HEAD.