### PR TITLE
fix: loop over `postgres_cluster` group instead of `all` in `pgbackrest` role

### DIFF
--- a/automation/roles/pgbackrest/tasks/ssh_keys.yml
+++ b/automation/roles/pgbackrest/tasks/ssh_keys.yml
@@ -90,7 +90,7 @@
 
 - name: known_hosts | Get public ssh keys of hosts (ssh-keyscan)
   ansible.builtin.command: "ssh-keyscan -trsa -p {{ hostvars[item].ansible_ssh_port | default(hostvars[item].ansible_port) | default(22) }} {{ item }}"
-  loop: "{{ groups['all'] }}"
+  loop: "{{ groups['postgres_cluster'] }}"
   register: ssh_known_host_keyscan
   changed_when: false
 


### PR DESCRIPTION
Not sure if this setting was a leftover or intended but: when looping over `loop: "{{ groups['all'] }}"`, this causes failures in inventories which have more nodes defined than just the ones used for `autobase`. Not all might be reachable from each other and scanning all of them for keys is also not needed AFAICS.

Other tasks in this file also use the `postgres_cluster` group.