### PR TITLE
Console (API): fix connection info string parsing

### DIFF
--- a/console/service/internal/watcher/consts.go
+++ b/console/service/internal/watcher/consts.go
@@ -6,5 +6,5 @@ const (
 	ContainerStatusDead     = "dead"
 
 	LogFieldSystemInfo     = "System info"
-	LogFieldConnectionInfo = "deploy_finish : Connection info"
+	LogFieldConnectionInfo = "vitabaks.autobase.deploy_finish : Connection info"
 )


### PR DESCRIPTION
Changed the value of `LogFieldConnectionInfo` to include the 'vitabaks.autobase' prefix for more specific task identification in ansible json log.