### PR TITLE
fix etcd dir ownership

### DIFF
--- a/automation/roles/etcd/tasks/main.yml
+++ b/automation/roles/etcd/tasks/main.yml
@@ -131,6 +131,15 @@
     dest: /etc/systemd/system/etcd.service
   tags: etcd, etcd_conf
 
+- name:  Ensurce proper permission /etc/etcd
+  ansible.builtin.file:
+    path: "{{ etcd_conf_dir | default('/etc/etcd') }}"
+    state: directory
+    owner: etcd
+    group: etcd
+    mode: "0750"
+  tags: etcd, etcd_start
+
 - name: Enable and start etcd service
   ansible.builtin.systemd:
     daemon_reload: true

--- a/automation/roles/etcd/tasks/main.yml
+++ b/automation/roles/etcd/tasks/main.yml
@@ -69,8 +69,11 @@
 
 - name: Create etcd conf directory
   ansible.builtin.file:
-    path: "{{ etcd_conf_dir }}"
+    path: "{{ etcd_conf_dir | default('/etc/etcd') }}"
     state: directory
+    owner: etcd
+    group: etcd
+    mode: "0750"
   tags: etcd, etcd_conf
 
 # TLS
@@ -130,15 +133,6 @@
     src: templates/etcd.service.j2
     dest: /etc/systemd/system/etcd.service
   tags: etcd, etcd_conf
-
-- name:  Ensurce proper permission /etc/etcd
-  ansible.builtin.file:
-    path: "{{ etcd_conf_dir | default('/etc/etcd') }}"
-    state: directory
-    owner: etcd
-    group: etcd
-    mode: "0750"
-  tags: etcd, etcd_start
 
 - name: Enable and start etcd service
   ansible.builtin.systemd:


### PR DESCRIPTION
Problem:
When installing PostgreSQL clusters on Debian 12 and Oracle Linux 9, the Enable and start etcd service task fails because /etc/etcd is owned by root.

Error:
```
Jul 26 19:33:11 pg-cluster1 systemd[1]: etcd.service: Failed with result 'timeout'.
Jul 26 19:33:11 pg-cluster1 bash[22046]: {"level":"warn","ts":"...","msg":"failed to publish local member to cluster","error":"etcdserver: request timed out"}
```

Fix:
Added a task to set the correct owner (etcd) and permissions for /etc/etcd before starting the service.

Testing:
Verified on Oracle Linux 9—etcd now starts correctly.