### PR TITLE
fix: `check_mode` improvements for `pgbackrest` role

### DIFF
--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -72,7 +72,9 @@
       until: package_status is success
       delay: 5
       retries: 3
-
+      when:
+        - not ansible_check_mode
+        
     - name: Clean dnf cache
       ansible.builtin.command: dnf clean all
   environment: "{{ proxy_env | default({}) }}"

--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -74,7 +74,7 @@
       retries: 3
       when:
         - not ansible_check_mode
-        
+
     - name: Clean dnf cache
       ansible.builtin.command: dnf clean all
   environment: "{{ proxy_env | default({}) }}"


### PR DESCRIPTION
similar to #1132 

without it, a dry-run of the config PB errors out when `pgbackrest` is included