### PR TITLE
fix: run `stanza_create` tasks in `config` playbook

### DIFF
--- a/automation/playbooks/deploy_pgcluster.yml
+++ b/automation/playbooks/deploy_pgcluster.yml
@@ -341,12 +341,6 @@
     - role: vitabaks.autobase.netdata
 
   tasks:
-    - name: Create pgbackrest stanza
-      ansible.builtin.include_role:
-        name: vitabaks.autobase.pgbackrest
-        tasks_from: stanza_create
-      when: pgbackrest_install | default(false) | bool
-
     - name: Install and configure pgbouncer
       ansible.builtin.include_role:
         name: vitabaks.autobase.pgbouncer

--- a/automation/roles/pgbackrest/tasks/main.yml
+++ b/automation/roles/pgbackrest/tasks/main.yml
@@ -226,6 +226,10 @@
     - not ansible_check_mode
   tags: pgbackrest, pgbackrest_ssh_keys
 
+- ansible.builtin.import_tasks: stanza_create.yml
+  when: pgbackrest_install | default(false) | bool
+  tags: pgbackrest, pgbackrest_stanza_create
+
 - ansible.builtin.import_tasks: cron.yml
   when:
     - pgbackrest_cron_jobs is defined


### PR DESCRIPTION
When doing so, the single task in the `deploy` PB isn't necessary anymore since the stanza will be created anyhow when running the `pgbackrest` role the first time (if this isn't already done in the `deploy` PB when `pgbackrest_install: true` is set, this is a different issue that should be tackled).