### PR TITLE
Add PostgreSQL minor version support for RedHat-based distributions

### DIFF
--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -103,10 +103,7 @@
           when:
             - ansible_distribution == "OracleLinux"
             - ansible_distribution_major_version is version("8", ">=")
-      vars:
-        pg_devel_package: "postgresql{{ postgresql_version | string | replace('.', '') }}-devel"
-      when:
-        - pg_devel_package in postgresql_packages
+      when: postgresql_packages|join(" ") is search("devel")
 
     # Install PostgreSQL Repository
     - name: Get pgdg-redhat-repo-latest.noarch.rpm

--- a/automation/roles/add_repository/tasks/main.yml
+++ b/automation/roles/add_repository/tasks/main.yml
@@ -80,30 +80,27 @@
       when: install_epel_repo|bool
       tags: install_epel_repo
 
-    # Add repository to install dependencies for postgresql<version>-devel package
-    - block:
-        # PowerTools repository
-        - name: Enable PowerTools repository
-          ansible.builtin.command: dnf config-manager --set-enabled "[Pp]ower[Tt]ools"
-          when:
-            - ansible_distribution_major_version is version("8", "==")
-            - ansible_distribution != "OracleLinux"
-            - ansible_distribution != "RedHat"
+    # PowerTools repository
+    - name: Enable PowerTools repository
+      ansible.builtin.command: dnf config-manager --set-enabled "[Pp]ower[Tt]ools"
+      when:
+        - ansible_distribution_major_version is version("8", "==")
+        - ansible_distribution != "OracleLinux"
+        - ansible_distribution != "RedHat"
 
-        # CodeReady Linux Builder (crb) repository
-        - name: Enable CodeReady Linux Builder (crb) repository
-          ansible.builtin.command: dnf config-manager --set-enabled crb
-          when:
-            - ansible_distribution_major_version is version("9", ">=")
-            - ansible_distribution != "OracleLinux"
+    # CodeReady Linux Builder (crb) repository
+    - name: Enable CodeReady Linux Builder (crb) repository
+      ansible.builtin.command: dnf config-manager --set-enabled crb
+      when:
+        - ansible_distribution_major_version is version("9", ">=")
+        - ansible_distribution != "OracleLinux"
 
-        # CodeReady Builder repository for OracleLinux
-        - name: Enable CodeReady Builder repository
-          ansible.builtin.command: dnf config-manager --enable ol{{ ansible_distribution_major_version }}_codeready_builder
-          when:
-            - ansible_distribution == "OracleLinux"
-            - ansible_distribution_major_version is version("8", ">=")
-      when: postgresql_packages|join(" ") is search("devel")
+    # CodeReady Builder repository for OracleLinux
+    - name: Enable CodeReady Builder repository
+      ansible.builtin.command: dnf config-manager --enable ol{{ ansible_distribution_major_version }}_codeready_builder
+      when:
+        - ansible_distribution == "OracleLinux"
+        - ansible_distribution_major_version is version("8", ">=")
 
     # Install PostgreSQL Repository
     - name: Get pgdg-redhat-repo-latest.noarch.rpm

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -212,7 +212,7 @@ consul_services:
 ############################################################
 
 postgresql_version: 17 # Postgres major version
-postgresql_version_minor: 5 # Postgres minor version (used only for RedHat-based distros). Set to 'latest' to install the latest available minor version.
+postgresql_version_minor: 5 # Postgres minor version (used only for RedHat-based distros). Set 'latest' to install the latest available minor version.
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)
@@ -1035,12 +1035,12 @@ install_epel_repo: true # or 'false' (installed from the package "epel-release-l
 # Full PostgreSQL package version string (e.g., "17.5-1PGDG.rhel9").
 # Used only on RedHat-based distributions, where any minor version can be installed from the PGDG repo.
 # On Debian/Ubuntu, only the latest minor is available for each major release.
-postgresql_package_release: 3 # release number of the package in the PGDG repository.
 postgresql_package_version_full: >-
   {% if postgresql_version_minor | string == 'latest' %}
   {% else %}
-    -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}
+  -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}
   {% endif %}
+postgresql_package_release: 3 # release number of the package in the PGDG repository.
 
 postgresql_os_specific_packages:
   Debian:

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1035,11 +1035,11 @@ install_epel_repo: true # or 'false' (installed from the package "epel-release-l
 # Full PostgreSQL package version string (e.g., "17.5-1PGDG.rhel9").
 # Used only on RedHat-based distributions, where any minor version can be installed from the PGDG repo.
 # On Debian/Ubuntu, only the latest minor is available for each major release.
-postgresql_package_version_full: >-
-  {% if postgresql_version_minor | string == 'latest' %}
-  {% else %}
-  -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}
-  {% endif %}
+postgresql_package_version_full: "\
+  {% if postgresql_version_minor | string == 'latest' %}\
+  {% else %}\
+  -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}\
+  {% endif %}"
 postgresql_package_release: 3 # release number of the package in the PGDG repository.
 
 postgresql_os_specific_packages:

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -212,7 +212,7 @@ consul_services:
 ############################################################
 
 postgresql_version: 17 # Postgres major version
-postgresql_version_minor: 5 # Postgres minor version (applicable to RedHat-based distributions)
+postgresql_version_minor: 5 # Postgres minor version (used only for RedHat-based distros). Set to 'latest' to install the latest available minor version.
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)
@@ -1035,7 +1035,12 @@ install_epel_repo: true # or 'false' (installed from the package "epel-release-l
 # Full PostgreSQL package version string (e.g., "17.5-1PGDG.rhel9").
 # Used only on RedHat-based distributions, where any minor version can be installed from the PGDG repo.
 # On Debian/Ubuntu, only the latest minor is available for each major release.
-postgresql_package_version_full: "{{ postgresql_version }}.{{ postgresql_version_minor }}-1PGDG.rhel{{ ansible_distribution_major_version }}"
+postgresql_package_release: 3 # release number of the package in the PGDG repository.
+postgresql_package_version_full: >-
+  {% if postgresql_version_minor | string == 'latest' %}
+  {% else %}
+    -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}
+  {% endif %}
 
 postgresql_os_specific_packages:
   Debian:
@@ -1054,11 +1059,11 @@ postgresql_os_specific_packages:
 #   - postgresql-{{ postgresql_version }}-pgaudit
 #   - postgresql-{{ postgresql_version }}-partman
   RedHat:
-    - postgresql{{ postgresql_version }}-{{ postgresql_package_version_full }}
-    - postgresql{{ postgresql_version }}-server-{{ postgresql_package_version_full }}
-    - postgresql{{ postgresql_version }}-contrib-{{ postgresql_package_version_full }}
-    - postgresql{{ postgresql_version }}-devel-{{ postgresql_package_version_full }}
-#   - postgresql{{ postgresql_version }}-debuginfo-{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-server{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-contrib{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-devel{{ postgresql_package_version_full }}
+#   - postgresql{{ postgresql_version }}-debuginfo{{ postgresql_package_version_full }}
 #   - pg_repack_{{ postgresql_version }}
 #   - pg_cron_{{ postgresql_version }}
 #   - pg_stat_kcache_{{ postgresql_version }}

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1041,6 +1041,8 @@ postgresql_package_version_full: "\
   -{{ postgresql_version }}.{{ postgresql_version_minor }}-{{ postgresql_package_release }}PGDG.rhel{{ ansible_distribution_major_version }}\
   {% endif %}"
 postgresql_package_release: 3 # release number of the package in the PGDG repository.
+# To find the correct release number, check the PGDG repository for your distribution, example:
+# https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-9-x86_64/
 
 postgresql_os_specific_packages:
   Debian:

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -212,7 +212,7 @@ consul_services:
 ############################################################
 
 postgresql_version: 17 # Postgres major version
-postgresql_version_minor: 5 # Postgres minor version (used only for RedHat-based distros). Set 'latest' to install the latest available minor version.
+postgresql_version_minor: "latest" # Postgres minor version (e.g. '5' for 17.5, or 'latest' for newest). Applicable only on RedHat-based distros.
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -211,7 +211,8 @@ consul_services:
 # PostgreSQL parameters
 ############################################################
 
-postgresql_version: 17
+postgresql_version: 17 # Postgres major version
+postgresql_version_minor: 5 # Postgres minor version (applicable to RedHat-based distributions)
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)
@@ -1031,6 +1032,11 @@ yum_repository: []
 install_postgresql_repo: true # or 'false' (installed from the package "pgdg-redhat-repo-latest.noarch.rpm")
 install_epel_repo: true # or 'false' (installed from the package "epel-release-latest.noarch.rpm")
 
+# Full PostgreSQL package version string (e.g., "17.5-1PGDG.rhel9").
+# Used only on RedHat-based distributions, where any minor version can be installed from the PGDG repo.
+# On Debian/Ubuntu, only the latest minor is available for each major release.
+postgresql_package_version_full: "{{ postgresql_version }}.{{ postgresql_version_minor }}-1PGDG.rhel{{ ansible_distribution_major_version }}"
+
 postgresql_os_specific_packages:
   Debian:
     - postgresql-{{ postgresql_version }}
@@ -1048,11 +1054,11 @@ postgresql_os_specific_packages:
 #   - postgresql-{{ postgresql_version }}-pgaudit
 #   - postgresql-{{ postgresql_version }}-partman
   RedHat:
-    - postgresql{{ postgresql_version }}
-    - postgresql{{ postgresql_version }}-server
-    - postgresql{{ postgresql_version }}-contrib
-    - postgresql{{ postgresql_version }}-devel
-#   - postgresql{{ postgresql_version }}-debuginfo
+    - postgresql{{ postgresql_version }}-{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-server-{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-contrib-{{ postgresql_package_version_full }}
+    - postgresql{{ postgresql_version }}-devel-{{ postgresql_package_version_full }}
+#   - postgresql{{ postgresql_version }}-debuginfo-{{ postgresql_package_version_full }}
 #   - pg_repack_{{ postgresql_version }}
 #   - pg_cron_{{ postgresql_version }}
 #   - pg_stat_kcache_{{ postgresql_version }}


### PR DESCRIPTION
Closes: https://github.com/vitabaks/autobase/issues/1182

This PR introduces `postgresql_version_minor` variable (default: latest), enabling precise installation of any desired PostgreSQL minor version from the PGDG repository on RedHat-based distributions.

### Details:
- On RHEL/CentOS/Alma/Rocky:
All minor versions of PostgreSQL are available in the PGDG [repository](https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-9-x86_64/). By specifying postgresql_version_minor (e.g., 5 for version 17.5), you can pin and install an exact package version using the postgresql_package_version_full variable.
- On Debian/Ubuntu:
Only the latest minor version for each major PostgreSQL release is available in the [repository](https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-17/). Therefore, there is no need to specify the minor version when installing packages; the most recent update will always be used.

This enhancement improves flexibility and repeatability for environments that require specific minor versions on RedHat-based systems, while retaining the simple default behavior on Debian-based platforms.
