### PR TITLE
Add support for host-level PostgreSQL parameters

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -391,7 +391,7 @@ postgresql_parameters:
 #  - { option: "deadlock_timeout", value: "2s" }
 #  - { option: "", value: "" }
 
-# To set a different parameter (e.g. shared_buffers) for a specific host, define in its inventory, example:
+# To set a different parameter (e.g., shared_buffers) for a specific host, define it in the inventory or host_vars. Example:
 # local_postgresql_parameters:
 #   - { option: "shared_buffers", value: "32GB" }
 

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -292,7 +292,8 @@ postgresql_extensions: []
 #  - { ext: "", db: "" }
 #  - { ext: "", db: "" }
 
-# Example PostgreSQL parameters (stored in DCS)
+# PostgreSQL parameters (cluster-wide, stored in DCS and applied to all nodes)
+# Note: To set host-level parameters, use 'local_postgresql_parameters' variable.
 postgresql_parameters:
   - { option: "max_connections", value: "1000" } # the actual limit is enforced at the connection pooler level (pool_size)
   - { option: "superuser_reserved_connections", value: "5" }
@@ -389,6 +390,10 @@ postgresql_parameters:
 #  - { option: "lock_timeout", value: "10s" } # reduce this timeout if possible
 #  - { option: "deadlock_timeout", value: "2s" }
 #  - { option: "", value: "" }
+
+# Example: To set a different shared_buffers value for a specific host, define in its inventory:
+# local_postgresql_parameters:
+#   - { option: "shared_buffers", value: "32GB" }
 
 # Set this variable to 'true' if you want the cluster to be automatically restarted
 # after changing the 'postgresql_parameters' variable that requires a restart in the 'config_pgcluster.yml' playbook.

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -391,7 +391,7 @@ postgresql_parameters:
 #  - { option: "deadlock_timeout", value: "2s" }
 #  - { option: "", value: "" }
 
-# Example: To set a different shared_buffers value for a specific host, define in its inventory:
+# To set a different parameter (e.g. shared_buffers) for a specific host, define in its inventory, example:
 # local_postgresql_parameters:
 #   - { option: "shared_buffers", value: "32GB" }
 

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -169,6 +169,11 @@ postgresql:
 #      password: rewind_password
   parameters:
     unix_socket_directories: {{ postgresql_unix_socket_dir }}
+{% if local_postgresql_parameters is defined and local_postgresql_parameters | length > 0 %}
+  {% for parameter in local_postgresql_parameters %}
+    {{ parameter.option }}: "{{ parameter.value }}"
+  {% endfor %}
+{% endif %}
 {% if postgresql_stats_temp_directory_path is defined and postgresql_stats_temp_directory_path != 'none' and postgresql_version | int <= 14 %}
     stats_temp_directory: {{ postgresql_stats_temp_directory_path }}
 {% endif %}

--- a/automation/roles/pre_checks/tasks/huge_pages.yml
+++ b/automation/roles/pre_checks/tasks/huge_pages.yml
@@ -4,7 +4,7 @@
 # and "huge_pages" is not 'off' in postgresql_parameters.
 
 - block:
-    - name: "HugePages | Get shared_buffers value from postgresql_parameters variable"
+    - name: "HugePages | Get shared_buffers value from postgresql parameters"
       ansible.builtin.set_fact:
         shared_buffers: "{{ postgresql_parameters_shared_buffers }}"
         shared_buffers_value: "{{ postgresql_parameters_shared_buffers | regex_search('[0-9]+') | int }}"

--- a/automation/roles/pre_checks/tasks/huge_pages.yml
+++ b/automation/roles/pre_checks/tasks/huge_pages.yml
@@ -10,12 +10,24 @@
         shared_buffers_value: "{{ postgresql_parameters_shared_buffers | regex_search('[0-9]+') | int }}"
         shared_buffers_unit: "{{ postgresql_parameters_shared_buffers | regex_search('[A-Za-z]+') | lower }}"
       vars:
+        # Prefer 'shared_buffers' from local_postgresql_parameters (host-level override),
+        # fallback to cluster-wide postgresql_parameters (DCS), else use default 128MB.
         postgresql_parameters_shared_buffers: >-
           {{
-            (postgresql_parameters
-            | selectattr('option', 'equalto', 'shared_buffers')
-            | map(attribute='value')
-            | first | default('128MB'))
+            (
+              local_postgresql_parameters | default([])
+              | selectattr('option', 'equalto', 'shared_buffers')
+              | map(attribute='value') | first
+            )
+            | default(
+                (
+                  postgresql_parameters | default([])
+                  | selectattr('option', 'equalto', 'shared_buffers')
+                  | map(attribute='value') | first
+                ),
+                true
+              )
+            | default('128MB')
           }}
 
     - name: "HugePages | Set variable: shared_buffers_gb"
@@ -133,8 +145,27 @@
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
         - huge_pages_total.stdout | default(0) | int < huge_pages_required | int
         - not sysctl_conf_vm_nr_hugepages_sufficient | default(false)
-        - (not huge_pages_auto_conf | bool or (not sysctl_set | bool and
-          (postgresql_parameters | selectattr('option', 'equalto', 'huge_pages') | map(attribute='value') | first | default('try')) == 'on'))
+        - (not huge_pages_auto_conf | bool or (not sysctl_set | bool and huge_pages_mode == 'on'))
+  vars:
+    # Prefer 'huge_pages' from local_postgresql_parameters (host override),
+    # fallback to cluster-wide postgresql_parameters (DCS), else 'try'.
+    huge_pages_mode: >-
+      {{
+        (
+          local_postgresql_parameters | default([])
+          | selectattr('option', 'equalto', 'huge_pages')
+          | map(attribute='value') | first
+        )
+        | default(
+            (
+              postgresql_parameters | default([])
+              | selectattr('option', 'equalto', 'huge_pages')
+              | map(attribute='value') | first
+            ),
+            true
+        )
+        | default('try')
+      }}
   when:
-    - (postgresql_parameters | selectattr('option', 'equalto', 'huge_pages') | map(attribute='value') | first | default('try')) != 'off'
-    - (sysctl_set | bool or (postgresql_parameters | selectattr('option', 'equalto', 'huge_pages') | map(attribute='value') | first | default('try')) == 'on')
+    - huge_pages_mode != 'off'
+    - (sysctl_set | bool or huge_pages_mode == 'on')


### PR DESCRIPTION
Added the `local_postgresql_parameters` variable to allow setting host-specific PostgreSQL parameters.
Updated the Patroni template to apply these parameters at the host level, enabling more granular configuration.

For example, if a cluster has a node with less RAM, you can override shared_buffers for that host without affecting other nodes:

```yaml
local_postgresql_parameters:
  - { option: "shared_buffers", value: "32GB" }
```