### PR TITLE
remove_cluster: Improve the pgBackRest stanza delete logic

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,8 @@ jobs:
           TAG: ${{ env.TAG }}
 
       - name: Run Docker push
-        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
+        # if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
+        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD }}
         run: make docker-push
         env:
           TAG: ${{ env.TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,8 +57,7 @@ jobs:
           TAG: ${{ env.TAG }}
 
       - name: Run Docker push
-        # if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
-        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD }}
+        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
         run: make docker-push
         env:
           TAG: ${{ env.TAG }}

--- a/automation/playbooks/remove_cluster.yml
+++ b/automation/playbooks/remove_cluster.yml
@@ -44,7 +44,6 @@
 
     - block:
         - name: Check if pgBackRest stanza exists
-          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} info"
           register: pgbackrest_info_result
@@ -52,14 +51,12 @@
           changed_when: false
 
         - name: Run pgBackRest stop
-          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stop --force"
           register: pgbackrest_stop_result
           when: pgbackrest_info_result.stdout is not search("missing stanza path") # skip if no stanza exists
 
         - name: Delete pgBackRest stanza
-          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stanza-delete --force"
           when: pgbackrest_stop_result is defined
@@ -73,7 +70,6 @@
             label: "{{ item.file }}"
 
         - name: Run pgBackRest start
-          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} start" # delete stop file (it exists)
           when: pgbackrest_stop_result is defined

--- a/automation/playbooks/remove_cluster.yml
+++ b/automation/playbooks/remove_cluster.yml
@@ -44,6 +44,7 @@
 
     - block:
         - name: Check if pgBackRest stanza exists
+          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} info"
           register: pgbackrest_info_result
@@ -51,12 +52,14 @@
           changed_when: false
 
         - name: Run pgBackRest stop
+          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stop --force"
           register: pgbackrest_stop_result
           when: pgbackrest_info_result.stdout is not search("missing stanza path") # skip if no stanza exists
 
         - name: Delete pgBackRest stanza
+          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stanza-delete --force"
           when: pgbackrest_stop_result is defined
@@ -70,6 +73,7 @@
             label: "{{ item.file }}"
 
         - name: Run pgBackRest start
+          become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} start" # delete stop file (it exists)
           when: pgbackrest_stop_result is defined

--- a/automation/playbooks/remove_cluster.yml
+++ b/automation/playbooks/remove_cluster.yml
@@ -43,19 +43,26 @@
       when: remove_postgres | default(false) | bool and inventory_hostname in groups['postgres_cluster']
 
     - block:
+        - name: Check if pgBackRest stanza exists
+          become: true
+          become_user: postgres
+          ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} info"
+          register: pgbackrest_info_result
+          failed_when: false
+          changed_when: false
+
         - name: Run pgBackRest stop
           become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stop --force"
           register: pgbackrest_stop_result
-          when: ('pgbackrest' in groups and groups['pgbackrest'] | length > 0 and inventory_hostname in groups['pgbackrest']) or
-            (('pgbackrest' not in groups or groups['pgbackrest'] | length == 0) and inventory_hostname == groups['postgres_cluster'][0])
+          when: pgbackrest_info_result.stdout is not search("missing stanza path") # skip if no stanza exists
 
         - name: Delete pgBackRest stanza
           become: true
           become_user: postgres
           ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} stanza-delete --force"
-          when: pgbackrest_stop_result is defined and pgbackrest_stop_result is changed
+          when: pgbackrest_stop_result is defined
 
         - name: Delete pgBackRest cron job
           ansible.builtin.file:
@@ -64,11 +71,20 @@
           loop: "{{ pgbackrest_cron_jobs | default(default_pgbackrest_cron_jobs) | unique(attribute='file') }}"
           loop_control:
             label: "{{ item.file }}"
+
+        - name: Run pgBackRest start
+          become: true
+          become_user: postgres
+          ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza | default(default_pgbackrest_stanza) }} start" # delete stop file (it exists)
+          when: pgbackrest_stop_result is defined
       vars:
         default_pgbackrest_stanza: "{{ patroni_cluster_name | default('postgres-cluster') }}"
         default_pgbackrest_cron_jobs: "{{ [{ 'file': '/etc/cron.d/pgbackrest-' ~ default_pgbackrest_stanza }] }}"
       ignore_errors: true
-      when: remove_pgbackrest | default(false) | bool
+      when:
+        - remove_pgbackrest | default(false) | bool
+        - ('pgbackrest' in groups and groups['pgbackrest'] | length > 0 and inventory_hostname in groups['pgbackrest']) or
+          (('pgbackrest' not in groups or groups['pgbackrest'] | length == 0) and inventory_hostname == groups['postgres_cluster'][0])
 
 - name: vitabaks.autobase.remove_cluster | Remove Consul Cluster
   hosts: consul_instances


### PR DESCRIPTION
Improve pgBackRest stanza delete logic
- Added a check to verify stanza existence before attempting deletion — deletion is skipped if the stanza is missing.
- After stanza deletion, run pgbackrest start to avoid cases where a leftover stop file prevents recreating the stanza.