### PR TITLE
fix: various fixes for `add_pgnode` playbook

### DIFF
--- a/automation/roles/pgbackrest/tasks/ssh_keys.yml
+++ b/automation/roles/pgbackrest/tasks/ssh_keys.yml
@@ -73,28 +73,33 @@
   ansible.posix.authorized_key:
     user: postgres
     state: present
-    key: "{{ hostvars[item].pgbackrest_server_sshkey['content'] | b64decode }}"
+    key: "{{ hostvars[item].get('pgbackrest_server_sshkey', {}).get('content', '') | b64decode }}"
   loop: "{{ groups['pgbackrest'] | default([]) }}"
-  when: "'postgres_cluster' in group_names"
+  when: 
+    - "'postgres_cluster' in group_names"
+    - hostvars[item].get('pgbackrest_server_sshkey') is not none
 
 - name: ssh_keys | Add database ssh keys in "~{{ pgbackrest_repo_user }}/.ssh/authorized_keys" on pgbackrest server
   ansible.posix.authorized_key:
     user: "{{ pgbackrest_repo_user }}"
     state: present
-    key: "{{ hostvars[item].postgres_cluster_sshkey['content'] | b64decode }}"
+    key: "{{ hostvars[item].get('postgres_cluster_sshkey', {}).get('content', '') | b64decode }}"
   loop: "{{ groups['postgres_cluster'] }}"
-  when: "'pgbackrest' in group_names"
+  when: 
+    - "'pgbackrest' in group_names"
+    - hostvars[item].get('postgres_cluster_sshkey') is not none
 
 # if 'backup-standby' are specified in pgbackrest_conf.global
 - name: ssh_keys | Add ssh keys in "~postgres/.ssh/authorized_keys" on database servers
   ansible.posix.authorized_key:
     user: postgres
     state: present
-    key: "{{ hostvars[item].postgres_cluster_sshkey['content'] | b64decode }}"
+    key: "{{ hostvars[item].get('postgres_cluster_sshkey', {}).get('content', '') | b64decode }}"
   loop: "{{ groups['postgres_cluster'] }}"
   when:
     - "'postgres_cluster' in group_names"
     - pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y'
+    - hostvars[item].get('postgres_cluster_sshkey') is not none
 
 - name: known_hosts | Get public ssh keys of hosts (ssh-keyscan)
   ansible.builtin.command: >
@@ -107,20 +112,24 @@
   become: true
   become_user: postgres
   ansible.builtin.known_hosts:
-    host: "{{ item.stdout.split(' ')[0] }}"
-    key: "{{ item.stdout }}"
+    host: "{{ item.stdout_lines | select('match', '^[^#].*') | first | split(' ') | first }}"
+    key: "{{ item.stdout_lines | select('match', '^[^#].*') | first }}"
     path: "~postgres/.ssh/known_hosts"
   no_log: true
   loop: "{{ ssh_known_host_keyscan.results }}"
-  when: "'postgres_cluster' in group_names"
+  when: 
+    - "'postgres_cluster' in group_names"
+    - item.stdout_lines | select('match', '^[^#].*') | list | length > 0
 
 - name: known_hosts | add ssh public keys in "~{{ pgbackrest_repo_user }}/.ssh/known_hosts" on pgbackrest server
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
   ansible.builtin.known_hosts:
-    host: "{{ item.stdout.split(' ')[0] }}"
-    key: "{{ item.stdout }}"
+    host: "{{ item.stdout_lines | select('match', '^[^#].*') | first | split(' ') | first }}"
+    key: "{{ item.stdout_lines | select('match', '^[^#].*') | first }}"
     path: "~{{ pgbackrest_repo_user }}/.ssh/known_hosts"
   no_log: true
   loop: "{{ ssh_known_host_keyscan.results }}"
-  when: "'pgbackrest' in group_names"
+  when: 
+    - "'pgbackrest' in group_names"
+    - item.stdout_lines | select('match', '^[^#].*') | list | length > 0

--- a/automation/roles/tls_certificate/tasks/copy.yml
+++ b/automation/roles/tls_certificate/tasks/copy.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Fetch TLS certificate, key and CA from {{ inventory_hostname }}"
+- name: "Fetch TLS certificate, key and CA from master node"
   ansible.builtin.slurp:
     src: "{{ fetch_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item }}"
   register: tls_files_raw
@@ -7,7 +7,8 @@
     - "{{ fetch_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
     - "{{ fetch_tls_cert | default(tls_cert | default('server.crt')) }}"
     - "{{ fetch_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
-  when: inventory_hostname == (groups[tls_group_name | default('master')][0])
+  delegate_to: "{{ groups[tls_group_name | default('master')][0] }}"
+  run_once: true
   tags: tls, tls_cert_copy
 
 - name: "Set variable: tls_files"
@@ -16,7 +17,7 @@
       server_key: "{{ tls_files_raw.results[0].content }}"
       server_crt: "{{ tls_files_raw.results[1].content }}"
       ca_crt: "{{ tls_files_raw.results[2].content }}"
-  when: inventory_hostname == (groups[tls_group_name | default('master')][0])
+  run_once: true
   tags: tls, tls_cert_copy
 
 - name: Create directory {{ copy_tls_dir | default(tls_dir | default('/etc/tls')) }}
@@ -30,7 +31,7 @@
 
 - name: Copy TLS certificate, key and CA to all nodes
   ansible.builtin.copy:
-    content: "{{ (hostvars[groups[tls_group_name | default('master')][0]].tls_files[item.key] | b64decode) }}"
+    content: "{{ (tls_files[item.key] | b64decode) }}"
     dest: "{{ copy_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item.filename }}"
     owner: "{{ copy_tls_owner | default(tls_owner | default('postgres')) }}"
     group: "{{ copy_tls_owner | default(tls_owner | default('postgres')) }}"


### PR DESCRIPTION
I faced various issues while executing this PB (with v2.3.1) due to undefined vars, issues when hosts are in multiple groups and the processing of raw command output in metadata filtering.

I am not sure if this was caused by some non-standard inventory setup, but AFAICS it should align with the suggested group patterns. With all these fixes, I was able to execute all tasks of the PB successfully. I am yet missing the `haproxy` LB on the new node and `patronitctl list` doesn't yet work, but this might be a different issue.

`ssh_keys.yml`:

Tasks were accessing SSH key variables from other hosts without checking if the variables were defined, causing 'dict object' has no attribute 'content' errors.

-> Replaced direct variable access with safer `.get()` method calls

The `known_hosts` module was receiving malformed SSH key data that included comment lines, causing "Host parameter does not match hashed host field" errors.

-> Filter out comment lines (starting with #) from ssh-keyscan output
-> Add safety checks to ensure valid SSH key data exists before processing

`copy.yml`:

The TLS certificate copy task was trying to access tls_files variable from the master node via hostvars, but the variable wasn't available when the `master` node wasn't included in the current play.

-> Use delegate_to to fetch TLS files directly from the master node
-> Set the `tls_files` fact locally instead of relying on hostvars access

---

My inventory looked like this:

```yaml
[etcd_cluster]
10.10.1.1 ansible_host=$IP 
10.10.1.2 ansible_host=$IP 
10.10.1.3 ansible_host=$IP 
10.10.5.2 ansible_host=$IP postgresql_exists=false new_node=true 

[balancers]
10.10.1.1 ansible_host=$IP  
10.10.1.2 ansible_host=$IP  
10.10.1.3 ansible_host=$IP 

[master]
10.10.1.1 hostname=pgnode1 ansible_host=$IP  postgresql_exists=false 
[replica]
10.10.1.2 hostname=pgnode2 ansible_host=$IP  postgresql_exists=false 
10.10.1.3 hostname=pgnode3 ansible_host=$IP  postgresql_exists=false 
10.10.5.2 ansible_host=$IP postgresql_exists=false new_node=true 

[pgbackrest]
10.11.1.1 ansible_host=$IP  
10.11.1.2 ansible_host=$IP 
10.11.1.3 ansible_host=$IP
10.10.5.2 ansible_host=$IP 

[postgres_cluster:children]
master
replica
```