### PR TITLE
fix: duplicate HAProxy IPs in connection info

### DIFF
--- a/automation/molecule/tests/roles/deploy-finish/variables/haproxy_nodes.yml
+++ b/automation/molecule/tests/roles/deploy-finish/variables/haproxy_nodes.yml
@@ -15,7 +15,7 @@
         groups['balancers']
         | default([])
         | map('extract', hostvars, 'inventory_hostname')
-        | join(',')
+        | join(', ')
       }}
 
 # 🖨️ Debugging the established haproxy_nodes
@@ -32,7 +32,7 @@
     that:
       - "haproxy_nodes is not none"
       - "haproxy_nodes != 'N/A'"
-      - "haproxy_nodes == 'una.name,10.172.0.21,10.172.0.22'"
+      - "haproxy_nodes == 'una.name, 10.172.0.21, 10.172.0.22'"
     fail_msg: "Test failed: haproxy_nodes is not set correctly."
     success_msg: "Test passed: haproxy_nodes is set correctly."
 
@@ -49,7 +49,7 @@
         groups['postgres_cluster']
         | default([])
         | map('extract', hostvars, 'inventory_hostname')
-        | join(',')
+        | join(', ')
       }}
 
 # 🖨️ Debugging the established postgres_cluster_nodes
@@ -66,6 +66,6 @@
     that:
       - "postgres_cluster_nodes is not none"
       - "postgres_cluster_nodes != 'N/A'"
-      - "postgres_cluster_nodes == 'una.name,10.172.0.21,10.172.0.22'"
+      - "postgres_cluster_nodes == 'una.name, 10.172.0.21, 10.172.0.22'"
     fail_msg: "Test failed: postgres_cluster_nodes is not set correctly."
     success_msg: "Test passed: postgres_cluster_nodes is set correctly."

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -102,18 +102,6 @@
 
 # if 'cluster_vip' is not defined
 - block:
-    - name: "Set variable: haproxy_bind_address_var"
-      ansible.builtin.set_fact:
-        haproxy_bind_address_var: "{{ haproxy_bind_address | default(bind_address, true) }}"
-      when: with_haproxy_load_balancing | bool
-
-    - name: "Set variable: patroni_bind_address_var"
-      ansible.builtin.set_fact:
-        patroni_bind_address_var: "{{ patroni_bind_address | default(bind_address, true) }}"
-      when: not with_haproxy_load_balancing | bool
-  when: cluster_vip is not defined or cluster_vip | length < 1
-
-- block:
     # if 'with_haproxy_load_balancing' is 'true'
     - name: Connection info
       run_once: true
@@ -160,8 +148,18 @@
   vars:
     public_haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
     public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
-    haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address_var') | join(',') }}"
-    postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address_var') | join(',') }}"
+    haproxy_ip_addresses: >-
+      {{
+        (groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address') | map('default', None, True) | list)
+        | zip(groups['balancers'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
+        | map('list') | map('select', 'truthy')| map('first') | unique | join(',')
+      }}
+    postgres_ip_addresses: >-
+      {{
+        (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | map('default', None, True) | list)
+        | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
+        | map('list') | map('select', 'truthy')| map('first') | unique | join(',')
+      }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"
     libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(',') }}"

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -150,15 +150,15 @@
     public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
     haproxy_ip_addresses: >-
       {{
-        (groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address') | list)
-        | zip(groups['balancers'] | default([]) | map('extract', hostvars, 'bind_address') | list)
-        | map('list') | map('select') | map('first') | unique | join(',')
+        groups['balancers'] | default([]) | map('extract', hostvars) |
+        map('community.general.dict_kv', 'haproxy_bind_address', 'bind_address') |
+        map('first') | unique | join(',')
       }}
     postgres_ip_addresses: >-
       {{
-        (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | list)
-        | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | list)
-        | map('list') | map('select') | map('first') | unique | join(',')
+        groups['postgres_cluster'] | default([]) | map('extract', hostvars) |
+        map('community.general.dict_kv', 'patroni_bind_address', 'bind_address') |
+        map('first') | unique | join(',')
       }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -148,8 +148,18 @@
   vars:
     public_haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
     public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
-    haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars) | map(attribute='haproxy_bind_address', default=bind_address) | join(',') }}"
-    postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars) | map(attribute='patroni_bind_address', default=bind_address) | join(',') }}"
+    haproxy_ip_addresses: >-
+      {{
+        (groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address') | list)
+        | zip(groups['balancers'] | default([]) | map('extract', hostvars, 'bind_address') | list)
+        | map('list') | map('select') | map('first') | unique | join(',')
+      }}
+    postgres_ip_addresses: >-
+      {{
+        (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | list)
+        | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | list)
+        | map('list') | map('select') | map('first') | unique | join(',')
+      }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"
     libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(',') }}"

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -146,23 +146,23 @@
       when: not with_haproxy_load_balancing | bool and not pgbouncer_install | bool
   ignore_errors: true
   vars:
-    public_haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
-    public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
+    public_haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(', ') }}"
+    public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(', ') }}"
     haproxy_ip_addresses: >-
       {{
         (groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address') | map('default', None, True) | list)
         | zip(groups['balancers'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
-        | map('list') | map('select', 'truthy') | map('first') | unique | join(',')
+        | map('list') | map('select', 'truthy') | map('first') | unique | join(', ')
       }}
     postgres_ip_addresses: >-
       {{
         (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | map('default', None, True) | list)
         | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
-        | map('list') | map('select', 'truthy') | map('first') | unique | join(',')
+        | map('list') | map('select', 'truthy') | map('first') | unique | join(', ')
       }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"
-    libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(',') }}"
+    libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(', ') }}"
     libpq_load_balance: "{{ '&load_balance_hosts=random' if postgresql_version | int >= 16 else '' }}"
   when:
     - (cluster_vip is not defined or cluster_vip | length < 1)

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -158,7 +158,13 @@
       {{
         (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | map('default', None, True) | list)
         | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
-        | map('list') | map('select', 'truthy')| map('first') | unique | join(',')
+        | map('list') | map('select', 'truthy') | map('first') | unique | join(',')
+      }}
+    postgres_ip_addresses: >-
+      {{
+        (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | map('default', None, True) | list)
+        | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
+        | map('list') | map('select', 'truthy') | map('first') | unique | join(',')
       }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -104,12 +104,12 @@
 - block:
     - name: "Set variable: haproxy_bind_address_var"
       ansible.builtin.set_fact:
-        haproxy_bind_address_var: "{{ haproxy_bind_address if haproxy_bind_address is defined else bind_address }}"
+        haproxy_bind_address_var: "{{ haproxy_bind_address | default(bind_address, true) }}"
       when: with_haproxy_load_balancing | bool
 
     - name: "Set variable: patroni_bind_address_var"
       ansible.builtin.set_fact:
-        patroni_bind_address_var: "{{ patroni_bind_address if patroni_bind_address is defined else bind_address }}"
+        patroni_bind_address_var: "{{ patroni_bind_address | default(bind_address, true) }}"
       when: not with_haproxy_load_balancing | bool
   when: cluster_vip is not defined or cluster_vip | length < 1
 

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -152,12 +152,6 @@
       {{
         (groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address') | map('default', None, True) | list)
         | zip(groups['balancers'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
-        | map('list') | map('select', 'truthy')| map('first') | unique | join(',')
-      }}
-    postgres_ip_addresses: >-
-      {{
-        (groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address') | map('default', None, True) | list)
-        | zip(groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'bind_address') | map('default', None, True) | list)
         | map('list') | map('select', 'truthy') | map('first') | unique | join(',')
       }}
     postgres_ip_addresses: >-

--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -102,6 +102,18 @@
 
 # if 'cluster_vip' is not defined
 - block:
+    - name: "Set variable: haproxy_bind_address_var"
+      ansible.builtin.set_fact:
+        haproxy_bind_address_var: "{{ haproxy_bind_address if haproxy_bind_address is defined else bind_address }}"
+      when: with_haproxy_load_balancing | bool
+
+    - name: "Set variable: patroni_bind_address_var"
+      ansible.builtin.set_fact:
+        patroni_bind_address_var: "{{ patroni_bind_address if patroni_bind_address is defined else bind_address }}"
+      when: not with_haproxy_load_balancing | bool
+  when: cluster_vip is not defined or cluster_vip | length < 1
+
+- block:
     # if 'with_haproxy_load_balancing' is 'true'
     - name: Connection info
       run_once: true
@@ -148,18 +160,8 @@
   vars:
     public_haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
     public_postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'ansible_ssh_host') | join(',') }}"
-    haproxy_ip_addresses: >-
-      {{
-        groups['balancers'] | default([]) | map('extract', hostvars) |
-        map('community.general.dict_kv', 'haproxy_bind_address', 'bind_address') |
-        map('first') | unique | join(',')
-      }}
-    postgres_ip_addresses: >-
-      {{
-        groups['postgres_cluster'] | default([]) | map('extract', hostvars) |
-        map('community.general.dict_kv', 'patroni_bind_address', 'bind_address') |
-        map('first') | unique | join(',')
-      }}
+    haproxy_ip_addresses: "{{ groups['balancers'] | default([]) | map('extract', hostvars, 'haproxy_bind_address_var') | join(',') }}"
+    postgres_ip_addresses: "{{ groups['postgres_cluster'] | default([]) | map('extract', hostvars, 'patroni_bind_address_var') | join(',') }}"
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"
     libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(',') }}"


### PR DESCRIPTION
Fixed an issue where the Connection info block for setups using HAProxy without a VIP address displayed multiple identical IP addresses.

Before:
```
TASK [vitabaks.autobase.deploy_finish : Connection info] ***********************
ok: [pgnode01] => {
    "msg": {
        "address": "10.172.0.20,10.172.0.20,10.172.0.20",
        "password": "************",
        "port": {
            "primary": "5000",
            "replica": "5001"
        },
        "superuser": "postgres"
    }
}
```

After:

```
TASK [vitabaks.autobase.deploy_finish : Connection info] ***********************
ok: [pgnode01] => {
    "msg": {
        "address": "10.172.0.20, 10.172.0.21, 10.172.0.22",
        "password": "************",
        "port": {
            "primary": "5000",
            "replica": "5001"
        },
        "superuser": "postgres"
    }
}
```