### PR TITLE
Starting console-UI without SSL

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -68,14 +68,15 @@ The Console stack consists of the following core components:
 
 6. Run Docker Compose:
 
-   without automatically handling SSL certificates for your domain (without using https connection to access console-UI):
    ```sh
-   docker compose up -d
+   # with Caddy proxy
+   docker compose -f docker-compose.caddy.yml up -d
    ```
 
-   to automatically handle SSL certificates for your domain (using https connection to access console-UI):
+	Or, without automatic handling of SSL certificates for your domain
    ```sh
-   docker compose -f docker-compose.caddy.yml up -d
+   # without Caddy proxy
+   docker compose up -d
    ```
 
 ## Notes

--- a/console/README.md
+++ b/console/README.md
@@ -66,14 +66,14 @@ The Console stack consists of the following core components:
    AUTH_TOKEN=your-secret-token     # Your authorization token
    ```
 
-6. Run Docker Compose
+6. Run Docker Compose:
 
-   with automatically handle SSL certificates for your domain (with using https connection to access console-UI):
+   to automatically handle SSL certificates for your domain (using https connection to access console-UI):
    ```sh
    docker compose up -d
    ```
 
-   without automatically handle SSL certificates for your domain (without using https connection to access console-UI):
+   without automatically handling SSL certificates for your domain (without using https connection to access console-UI):
    ```sh
    docker compose -f docker-compose.non-ssl.yml up -d
    ```

--- a/console/README.md
+++ b/console/README.md
@@ -68,12 +68,12 @@ The Console stack consists of the following core components:
 
 6. Run Docker Compose
 
-   with automatically handle SSL certificates for your domain (with using https connection to access UI-console):
+   with automatically handle SSL certificates for your domain (with using https connection to access console-UI):
    ```sh
    docker compose up -d
    ```
 
-   without automatically handle SSL certificates for your domain (without using https connection to access UI-console):
+   without automatically handle SSL certificates for your domain (without using https connection to access console-UI):
    ```sh
    docker compose -f docker-compose.non-ssl.yml up -d
    ```

--- a/console/README.md
+++ b/console/README.md
@@ -61,14 +61,21 @@ The Console stack consists of the following core components:
 5. Configure your `.env`:
 
    ```sh
-   DOMAIN=autobase.your-domain.com  # Set your domain
-   EMAIL=admin@your-domain.com      # Required for Caddy SSL
+   DOMAIN=autobase.your-domain.com  # Set your domain (required for Caddy SSL)
+   EMAIL=admin@your-domain.com      # Set your email (required for Caddy SSL)
    AUTH_TOKEN=your-secret-token     # Your authorization token
    ```
 
-6. Run Docker Compose:
+6. Run Docker Compose
+
+   with automatically handle SSL certificates for your domain (with using https connection to access UI-console):
    ```sh
    docker compose up -d
+   ```
+
+   without automatically handle SSL certificates for your domain (without using https connection to access UI-console):
+   ```sh
+   docker compose -f docker-compose.non-ssl.yml up -d
    ```
 
 ## Notes

--- a/console/README.md
+++ b/console/README.md
@@ -68,14 +68,14 @@ The Console stack consists of the following core components:
 
 6. Run Docker Compose:
 
-   to automatically handle SSL certificates for your domain (using https connection to access console-UI):
+   without automatically handling SSL certificates for your domain (without using https connection to access console-UI):
    ```sh
    docker compose up -d
    ```
 
-   without automatically handling SSL certificates for your domain (without using https connection to access console-UI):
+   to automatically handle SSL certificates for your domain (using https connection to access console-UI):
    ```sh
-   docker compose -f docker-compose.non-ssl.yml up -d
+   docker compose -f docker-compose.caddy.yml up -d
    ```
 
 ## Notes

--- a/console/docker-compose.caddy.yml
+++ b/console/docker-compose.caddy.yml
@@ -1,5 +1,22 @@
 ---
 services:
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    container_name: caddy
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - CADDY_INGRESS_NETWORKS=caddy
+    networks:
+      - caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    restart: unless-stopped
+    labels:
+      caddy.email: ${EMAIL}
+
   autobase-console-api:
     image: autobase/console_api:2.3.2
     container_name: autobase-console-api
@@ -12,9 +29,6 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    depends_on:
-      autobase-console-db:
-        condition: service_healthy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/ansible:/tmp/ansible
@@ -24,26 +38,26 @@ services:
       - PG_CONSOLE_DB_HOST=autobase-console-db
     networks:
       - autobase
+      - caddy
 
   autobase-console-ui:
     image: autobase/console_ui:2.3.2
     container_name: autobase-console-ui
-    ports:
-      - 80:80
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:80/" ]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    depends_on:
-      autobase-console-api:
-        condition: service_healthy
+    labels:
+      caddy: ${DOMAIN}
+      caddy.reverse_proxy: autobase-console-ui:80
     environment:
       - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
       - PG_CONSOLE_API_HOST=autobase-console-api
     networks:
       - autobase
+      - caddy
 
   autobase-console-db:
     image: autobase/console_db:2.3.2
@@ -62,8 +76,11 @@ services:
 volumes:
   console_postgres:
     name: console_postgres
+  caddy_data:
+    name: caddy_data
 
 networks:
   autobase:
     name: autobase
-
+  caddy:
+    name: caddy

--- a/console/docker-compose.caddy.yml
+++ b/console/docker-compose.caddy.yml
@@ -14,6 +14,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - caddy_data:/data
     restart: unless-stopped
+    depends_on:
+      autobase-console-ui:
+        condition: service_healthy
     labels:
       caddy.email: ${EMAIL}
 
@@ -29,6 +32,9 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    depends_on:
+      autobase-console-db:
+        condition: service_healthy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/ansible:/tmp/ansible
@@ -49,6 +55,9 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    depends_on:
+      autobase-console-api:
+        condition: service_healthy
     labels:
       caddy: ${DOMAIN}
       caddy.reverse_proxy: autobase-console-ui:80

--- a/console/docker-compose.non-ssl.yml
+++ b/console/docker-compose.non-ssl.yml
@@ -15,7 +15,6 @@ services:
     depends_on:
       autobase-console-db:
         condition: service_healthy
-        restart: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/ansible:/tmp/ansible
@@ -40,7 +39,6 @@ services:
     depends_on:
       autobase-console-api:
         condition: service_healthy
-        restart: true
     environment:
       - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
       - PG_CONSOLE_API_HOST=autobase-console-api

--- a/console/docker-compose.non-ssl.yml
+++ b/console/docker-compose.non-ssl.yml
@@ -1,0 +1,71 @@
+---
+services:
+  autobase-console-api:
+    image: autobase/console_api:2.3.2
+    container_name: autobase-console-api
+    healthcheck:
+      test: ["CMD", "curl", "-fsS",
+            "-H", "accept: application/json",
+            "-H", "Authorization: Bearer ${AUTH_TOKEN}",
+            "http://localhost:8080/api/v1/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    depends_on:
+      autobase-console-db:
+        condition: service_healthy
+        restart: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/ansible:/tmp/ansible
+    environment:
+      - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
+      - PG_CONSOLE_LOGGER_LEVEL=${PG_CONSOLE_LOGGER_LEVEL:-INFO}
+      - PG_CONSOLE_DB_HOST=autobase-console-db
+    networks:
+      - autobase
+
+  autobase-console-ui:
+    image: autobase/console_ui:2.3.2
+    container_name: autobase-console-ui
+    ports:
+      - 80:80
+    healthcheck:
+      test: [ "CMD", "curl", "http://localhost:80/" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    depends_on:
+      autobase-console-api:
+        condition: service_healthy
+        restart: true
+    environment:
+      - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
+      - PG_CONSOLE_API_HOST=autobase-console-api
+    networks:
+      - autobase
+
+  autobase-console-db:
+    image: autobase/console_db:2.3.2
+    container_name: autobase-console-db
+    healthcheck:
+      test: pg_isready -U postgres -h 127.0.0.1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+    volumes:
+      - console_postgres:/var/lib/postgresql
+    networks:
+      - autobase
+
+volumes:
+  console_postgres:
+    name: console_postgres
+
+networks:
+  autobase:
+    name: autobase
+

--- a/console/docker-compose.yml
+++ b/console/docker-compose.yml
@@ -1,22 +1,5 @@
 ---
 services:
-  caddy:
-    image: lucaslorentz/caddy-docker-proxy:ci-alpine
-    container_name: caddy
-    ports:
-      - 80:80
-      - 443:443
-    environment:
-      - CADDY_INGRESS_NETWORKS=caddy
-    networks:
-      - caddy
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - caddy_data:/data
-    restart: unless-stopped
-    labels:
-      caddy.email: ${EMAIL}
-
   autobase-console-api:
     image: autobase/console_api:2.3.2
     container_name: autobase-console-api
@@ -29,6 +12,9 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    depends_on:
+      autobase-console-db:
+        condition: service_healthy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/ansible:/tmp/ansible
@@ -38,26 +24,26 @@ services:
       - PG_CONSOLE_DB_HOST=autobase-console-db
     networks:
       - autobase
-      - caddy
 
   autobase-console-ui:
     image: autobase/console_ui:2.3.2
     container_name: autobase-console-ui
+    ports:
+      - 80:80
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:80/" ]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    labels:
-      caddy: ${DOMAIN}
-      caddy.reverse_proxy: autobase-console-ui:80
+    depends_on:
+      autobase-console-api:
+        condition: service_healthy
     environment:
       - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
       - PG_CONSOLE_API_HOST=autobase-console-api
     networks:
       - autobase
-      - caddy
 
   autobase-console-db:
     image: autobase/console_db:2.3.2
@@ -76,11 +62,8 @@ services:
 volumes:
   console_postgres:
     name: console_postgres
-  caddy_data:
-    name: caddy_data
 
 networks:
   autobase:
     name: autobase
-  caddy:
-    name: caddy
+

--- a/console/docker-compose.yml
+++ b/console/docker-compose.yml
@@ -66,5 +66,3 @@ volumes:
 networks:
   autobase:
     name: autobase
-
-


### PR DESCRIPTION
Hi,

I encountered a problem with quickly launching console-UI in a private network without internet access.

I created a new `docker-compose.non-ssl.yml` file to launch the console without using Caddy and automatically handle an SSL certificate.

This will be useful for launching the console in private networks and in networks where an external proxy with its own SSL certificate is used.

Thanks