### PR TITLE
Allow customizing connect address and patroni postgresql authentication options

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -15,16 +15,12 @@ patroni_cluster_name: "postgres-cluster" # the cluster name (must be unique for 
 patroni_superuser_username: "postgres"
 patroni_superuser_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
 patroni_superuser_auth_options:
-  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" }
-  - { option: "sslkey", value: "{{ tls_dir }}/{{ tls_privatekey }}" }
-  - { option: "sslcert", value: "{{ tls_dir }}/{{ tls_cert }}" }
+  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" } # or 'verify-ca', 'verify-full'
   - { option: "sslrootcert", value: "{{ tls_dir }}/{{ tls_ca_cert }}" } # or 'system'
 patroni_replication_username: "replicator"
 patroni_replication_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
 patroni_replication_auth_options:
-  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" }
-  - { option: "sslkey", value: "{{ tls_dir }}/{{ tls_privatekey }}" }
-  - { option: "sslcert", value: "{{ tls_dir }}/{{ tls_cert }}" }
+  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" } # or 'verify-ca', 'verify-full'
   - { option: "sslrootcert", value: "{{ tls_dir }}/{{ tls_ca_cert }}" } # or 'system'
 # Note: if sslmode: verify-full, and your certificate doesn't have IP address in the SAN,
 # set also the option postgresql_connect_addr to ensure TLS certificate validation is successful.

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -14,17 +14,20 @@ patroni_cluster_name: "postgres-cluster" # the cluster name (must be unique for 
 
 patroni_superuser_username: "postgres"
 patroni_superuser_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
-patroni_superuser_auth_options: [] # In case non-standard auth options are needed, such as TLS certificate validation.
-  # - { option: "sslmode", value: "verify-full" }
-  # - { option: "sslrootcert", value: "system" }
+patroni_superuser_auth_options:
+  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" }
+  - { option: "sslkey", value: "{{ tls_dir }}/{{ tls_privatekey }}" }
+  - { option: "sslcert", value: "{{ tls_dir }}/{{ tls_cert }}" }
+  - { option: "sslrootcert", value: "{{ tls_dir }}/{{ tls_ca_cert }}" } # or 'system'
 patroni_replication_username: "replicator"
 patroni_replication_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
-patroni_replication_auth_options: [] # In case non-standard auth options are needed, such as TLS certificate validation.
-  # - { option: "sslmode", value: "verify-full" }
-  # - { option: "sslrootcert", value: "system" }
+patroni_replication_auth_options:
+  - { option: "sslmode", value: "{{ 'require' if tls_cert_generate | bool else 'disable' }}" }
+  - { option: "sslkey", value: "{{ tls_dir }}/{{ tls_privatekey }}" }
+  - { option: "sslcert", value: "{{ tls_dir }}/{{ tls_cert }}" }
+  - { option: "sslrootcert", value: "{{ tls_dir }}/{{ tls_ca_cert }}" } # or 'system'
 # Note: if sslmode: verify-full, and your certificate doesn't have IP address in the SAN,
-# set also the option postgresql_connect_addr to ensure TLS certificate validation is successful:
-# postgresql_connect_addr: "{{ hostname }}" # hostname is defined in the inventory.
+# set also the option postgresql_connect_addr to ensure TLS certificate validation is successful.
 
 synchronous_mode: false # or 'true' for enable synchronous database replication
 synchronous_mode_strict: false # if 'true' then block all client writes to the master, when a synchronous replica is not available
@@ -483,7 +486,7 @@ pgbouncer_pools:
 # Patroni parameters
 ############################################################
 
-# patroni_restapi_connect_addr: "{{ hostname }}" # Set if you need connection to be established by domain name, not IP.
+# patroni_restapi_connect_addr: "{{ ansible_hostname }}" # or 'ansible_fqdn'. Set if you need connection to be established by domain name, not IP.
 patroni_restapi_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }}" to listen on a specific IP address.
 patroni_restapi_port: 8008
 patroni_restapi_username: "patroni"

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -14,8 +14,17 @@ patroni_cluster_name: "postgres-cluster" # the cluster name (must be unique for 
 
 patroni_superuser_username: "postgres"
 patroni_superuser_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
+patroni_superuser_auth_options: [] # In case non-standard auth options are needed, such as TLS certificate validation.
+  # - { option: "sslmode", value: "verify-full" }
+  # - { option: "sslrootcert", value: "system" }
 patroni_replication_username: "replicator"
 patroni_replication_password: "" # Please specify a password. If not defined, will be generated automatically during deployment.
+patroni_replication_auth_options: [] # In case non-standard auth options are needed, such as TLS certificate validation.
+  # - { option: "sslmode", value: "verify-full" }
+  # - { option: "sslrootcert", value: "system" }
+# Note: if sslmode: verify-full, and your certificate doesn't have IP adress in the SAN,
+# set also the option postgresql_connect_addr to ensure TLS certificate validation is successful:
+# postgresql_connect_addr: "{{ hostname }}" # hostname is defined in the inventory.
 
 synchronous_mode: false # or 'true' for enable synchronous database replication
 synchronous_mode_strict: false # if 'true' then block all client writes to the master, when a synchronous replica is not available

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -225,7 +225,7 @@ consul_services:
 
 postgresql_version: 17 # Postgres major version
 postgresql_version_minor: "latest" # Postgres minor version (e.g. '5' for 17.5, or 'latest' for newest). Applicable only on RedHat-based distros.
-# postgresql_connect_addr: "{{ hostname }}" # Set in case you would like connections to be established by domain name, not IP.
+# postgresql_connect_addr: "{{ ansible_hostname }}" # or 'ansible_fqdn'. Set in case you would like connections to be established by domain name, not IP.
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -213,6 +213,7 @@ consul_services:
 
 postgresql_version: 17 # Postgres major version
 postgresql_version_minor: "latest" # Postgres minor version (e.g. '5' for 17.5, or 'latest' for newest). Applicable only on RedHat-based distros.
+# postgresql_connect_addr: "{{ hostname }}" # Set in case you would like connections to be established by domain name, not IP.
 postgresql_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }},127.0.0.1" to listen on a specific IP address.
 postgresql_port: 5432
 postgresql_encoding: "UTF8" # for bootstrap only (initdb)
@@ -473,6 +474,7 @@ pgbouncer_pools:
 # Patroni parameters
 ############################################################
 
+# patroni_restapi_connect_addr: "{{ hostname }}" # Set if you need connection to be established by domain name, not IP.
 patroni_restapi_listen_addr: "0.0.0.0" # Listen on all interfaces. Or use "{{ bind_address }}" to listen on a specific IP address.
 patroni_restapi_port: 8008
 patroni_restapi_username: "patroni"

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -22,7 +22,7 @@ patroni_replication_password: "" # Please specify a password. If not defined, wi
 patroni_replication_auth_options: [] # In case non-standard auth options are needed, such as TLS certificate validation.
   # - { option: "sslmode", value: "verify-full" }
   # - { option: "sslrootcert", value: "system" }
-# Note: if sslmode: verify-full, and your certificate doesn't have IP adress in the SAN,
+# Note: if sslmode: verify-full, and your certificate doesn't have IP address in the SAN,
 # set also the option postgresql_connect_addr to ensure TLS certificate validation is successful:
 # postgresql_connect_addr: "{{ hostname }}" # hostname is defined in the inventory.
 

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -22,7 +22,7 @@ log:
 
 restapi:
   listen: {{ patroni_restapi_listen_addr }}:{{ patroni_restapi_port }}
-  connect_address: {{ patroni_bind_address | default(bind_address, true) }}:{{ patroni_restapi_port }}
+  connect_address: {{ patroni_restapi_connect_addr | default(patroni_bind_address | default(bind_address, true), true) }}:{{ patroni_restapi_port }}
 #  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
 #  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
 {% if patroni_restapi_password | default('') | length > 0 %}
@@ -149,7 +149,7 @@ bootstrap:
 
 postgresql:
   listen: {{ postgresql_listen_addr }}:{{ postgresql_port }}
-  connect_address: {{ patroni_bind_address | default(bind_address, true) }}:{{ postgresql_port }}
+  connect_address: {{ postgresql_connect_addr | default(patroni_bind_address | default(bind_address, true), true) }}:{{ postgresql_port }}
 {% if patroni_superuser_username == 'postgres' %}
   use_unix_socket: true
 {% endif %}

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -161,9 +161,15 @@ postgresql:
     replication:
       username: {{ patroni_replication_username }}
       password: {{ patroni_replication_password }}
+{% for parameter in patroni_replication_auth_options %}
+      {{ parameter.option }}: {{ parameter.value }}
+{% endfor %}
     superuser:
       username: {{ patroni_superuser_username }}
       password: {{ patroni_superuser_password }}
+{% for parameter in patroni_superuser_auth_options %}
+      {{ parameter.option }}: {{ parameter.value }}
+{% endfor %}
 #    rewind:  # Has no effect on postgres 10 and lower
 #      username: rewind_user
 #      password: rewind_password


### PR DESCRIPTION
1. Introduce new variables `patroni_superuser_auth_options` and `patroni_replication_auth_options`. The new variables enable the option to harden TLS connection by requiring certificate verification.
Resolves #1227 .
2. Allow customizing connect_address with new variables `patroni_restapi_connect_addr` and `postgresql_connect_addr`. When set to "{{ hostname }}", postgres and patroni will connect using the domain name, instead of IP address. This allows certificate validation, when `sslmode=verify-full`, and TLS certificate is issued only for domain, but not for the IP.
Resolves: #1228 