### PR TITLE
Introduce patroni_use_unix_socket and patroni_use_unix_socket_repl

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -495,6 +495,9 @@ patroni_master_start_timeout: 300
 patroni_maximum_lag_on_failover: 1048576 # (1MB) the maximum bytes a follower may lag to be able to participate in leader election.
 patroni_maximum_lag_on_replica: "100MB" # the maximum of lag that replica can be in order to be available for read-only queries.
 
+patroni_use_unix_socket: true # specifies that Patroni should prefer to use unix sockets to connect to the cluster.
+patroni_use_unix_socket_repl: true # specifies that Patroni should prefer to use unix sockets for replication user cluster connection.
+
 # https://patroni.readthedocs.io/en/latest/yaml_configuration.html#postgresql
 patroni_callbacks: []
 #  - {action: "on_role_change", script: ""}

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -412,7 +412,6 @@ pending_restart: false
 postgresql_pg_hba:
   - { type: "local", database: "all", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "{{ pgbouncer_auth_username }}", address: "", method: "trust" } # required for pgbouncer auth_user
-  - { type: "local", database: "replication", user: "{{ patroni_replication_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "all", address: "", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "127.0.0.1/32", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "::1/128", method: "{{ postgresql_password_encryption_algorithm }}" }

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -150,8 +150,11 @@ bootstrap:
 postgresql:
   listen: {{ postgresql_listen_addr }}:{{ postgresql_port }}
   connect_address: {{ postgresql_connect_addr | default(patroni_bind_address | default(bind_address, true), true) }}:{{ postgresql_port }}
-{% if patroni_superuser_username == 'postgres' %}
+{% if patroni_superuser_username == 'postgres' or (patroni_use_unix_socket | default(false)) %}
   use_unix_socket: true
+{% endif %}
+{% if patroni_use_unix_socket_repl | default(false) %}
+  use_unix_socket_repl: true
 {% endif %}
   data_dir: {{ postgresql_data_dir }}
   bin_dir: {{ postgresql_bin_dir }}

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -146,11 +146,10 @@ bootstrap:
     - host replication {{ patroni_replication_username }} 127.0.0.1/32 {{ postgresql_password_encryption_algorithm }}
     - host all all 0.0.0.0/0 {{ postgresql_password_encryption_algorithm }}
 
-
 postgresql:
   listen: {{ postgresql_listen_addr }}:{{ postgresql_port }}
   connect_address: {{ postgresql_connect_addr | default(patroni_bind_address | default(bind_address, true), true) }}:{{ postgresql_port }}
-{% if patroni_superuser_username == 'postgres' and patroni_use_unix_socket | default(false) %}
+{% if patroni_use_unix_socket | default(false) %}
   use_unix_socket: true
 {% endif %}
 {% if patroni_use_unix_socket_repl | default(false) %}

--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -150,7 +150,7 @@ bootstrap:
 postgresql:
   listen: {{ postgresql_listen_addr }}:{{ postgresql_port }}
   connect_address: {{ postgresql_connect_addr | default(patroni_bind_address | default(bind_address, true), true) }}:{{ postgresql_port }}
-{% if patroni_superuser_username == 'postgres' or (patroni_use_unix_socket | default(false)) %}
+{% if patroni_superuser_username == 'postgres' and patroni_use_unix_socket | default(false) %}
   use_unix_socket: true
 {% endif %}
 {% if patroni_use_unix_socket_repl | default(false) %}

--- a/automation/roles/patroni/templates/pg_hba.conf.j2
+++ b/automation/roles/patroni/templates/pg_hba.conf.j2
@@ -92,12 +92,11 @@
 {% endfor %}
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
-{% if not patroni_use_unix_socket_repl | default(false) %}
+{% if patroni_use_unix_socket_repl | default(false) %}
+  local      replication               {{ patroni_replication_username }}                                          trust
+{% else %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               localhost                trust
 {% endif %}
 {% for host in groups['postgres_cluster'] %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}/32         {{ postgresql_password_encryption_algorithm }}
 {% endfor %}
-{% if patroni_use_unix_socket_repl | default(false) %}
-  local      replication               {{ patroni_replication_username }}                                          {{ postgresql_password_encryption_algorithm }}
-{% endif %}

--- a/automation/roles/patroni/templates/pg_hba.conf.j2
+++ b/automation/roles/patroni/templates/pg_hba.conf.j2
@@ -96,3 +96,6 @@
 {% for host in groups['postgres_cluster'] %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}/32         {{ postgresql_password_encryption_algorithm }}
 {% endfor %}
+{% if patroni_use_unix_socket_repl | default(false) %}
+  local      replication               {{ patroni_replication_username }}                                          {{ postgresql_password_encryption_algorithm }}
+{% endif %}

--- a/automation/roles/patroni/templates/pg_hba.conf.j2
+++ b/automation/roles/patroni/templates/pg_hba.conf.j2
@@ -92,7 +92,9 @@
 {% endfor %}
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
+{% if not patroni_use_unix_socket_repl | default(false) %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               localhost                trust
+{% endif %}
 {% for host in groups['postgres_cluster'] %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}/32         {{ postgresql_password_encryption_algorithm }}
 {% endfor %}

--- a/automation/roles/patroni/templates/pg_hba.conf.j2
+++ b/automation/roles/patroni/templates/pg_hba.conf.j2
@@ -93,7 +93,7 @@
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
 {% if patroni_use_unix_socket_repl | default(false) %}
-  local      replication               {{ patroni_replication_username }}                                          trust
+  local        replication              {{ patroni_replication_username }}                                      trust
 {% else %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      replication              {{ patroni_replication_username }}               localhost                trust
 {% endif %}


### PR DESCRIPTION
The new parameters allow configuring
postgresql.use_unix_socket
postgresql.use_unix_socket_repl

use_unix_socket_repl is particularly useful when TLS is enabled for replication user with sslmode=verify-full . Communicating over socket avoids a problem of validating TLS certificate for the domain localhost, to which patroni tries to connect by default, if use_unix_socket_repl isn't set. By connecting to the socket, encrypted connection isn't used, avoiding the validation problem.

Resolves: #1231