### PR TITLE
Fix pgbouncer pause command in upgrade role

### DIFF
--- a/automation/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/automation/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -68,7 +68,7 @@
     pgb_servers="$pg_servers"
     pgb_servers_count="$pg_servers_count"
     pgb_count="{{ (groups['primary'] | default([]) | length + groups['secondary'] | default([]) | length) * (pgbouncer_processes | default(1) | int) }}"
-    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 timeout {{ pgbouncer_pool_pause_timeout }} PGPASSWORD='{{ patroni_superuser_password }}' psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
+    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 env PGPASSWORD='{{ patroni_superuser_password }}' timeout {{ pgbouncer_pool_pause_timeout }} psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
     pgb_resume_command='kill -SIGUSR2 $(pidof pgbouncer)'
 
     start_time=$(date +%s)
@@ -122,6 +122,7 @@
     executable: /bin/bash
   register: pgbouncer_pool_pause_result
   ignore_errors: true
+  no_log: true # do not output contents to the ansible log
   when: inventory_hostname in groups['primary']
 
 # Stop, if it was not possible to put the pools on pause


### PR DESCRIPTION
Use 'env' to set PGPASSWORD for the psql command instead of inline assignment, improving compatibility. Add 'no_log: true' to prevent sensitive information from being logged by Ansible.

Fixed:

```
  fatal: [pgnode01]: FAILED! => {"changed": true, "cmd": "set -o pipefail;\n\npg_servers=\"10.172.2.20\\n10.172.2.21\\n10.172.2.22\"\npg_servers_count=\"3\"\npg_slow_active_count_query=\"select count(*) from pg_stat_activity where pid <> pg_backend_pid() and state <> 'idle' and query_start < clock_timestamp() - interval '1000 ms' and backend_type = 'client backend'\"\npg_slow_active_terminate_query=\"select\n  clock_timestamp(),\n  pg_terminate_backend(pid),\n  clock_timestamp() - query_start as query_age,\n  left(regexp_replace(query, E'[ \\\\t\\\\n\\\\r]+', ' ', 'g'),150) as query\nfrom pg_stat_activity where pid <> pg_backend_pid() and state <> 'idle' and query_start < clock_timestamp() - interval '100 ms' and backend_type = 'client backend'\"\n# it is assumed that pgbouncer is installed on database servers\npgb_servers=\"$pg_servers\"\npgb_servers_count=\"$pg_servers_count\"\npgb_count=\"12\"\npgb_pause_command=\"printf '%s\\n' /var/run/pgbouncer /var/run/pgbouncer-2 /var/run/pgbouncer-3 /var/run/pgbouncer-4 | xargs -I {} -P 4 -n 1 timeout 2 PGPASSWORD='x8ivlzqOMhURoK7xUk8tVWxFOdJLdES0' psql -h {} -p 6432 -U postgres -d pgbouncer -tAXc 'PAUSE'\"\npgb_resume_command='kill -SIGUSR2 $(pidof pgbouncer)'\n\nstart_time=$(date +%s)\nwhile true; do\n  current_time=$(date +%s)\n  # initialize pgb_paused_count to 0 (we assume that all pgbouncers are not paused)\n  pgb_paused_count=0\n\n  # wait for the active queries to complete on pg_servers\n  IFS=$'\\n' pg_slow_active_counts=($(echo -e \"$pg_servers\" | xargs -I {} -P \"$pg_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"PGPASSWORD='x8ivlzqOMhURoK7xUk8tVWxFOdJLdES0' psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -tAXc \\\"$pg_slow_active_count_query\\\"\"))\n\n  # sum up all the values in the array\n  total_pg_slow_active_count=0\n  for count in \"${pg_slow_active_counts[@]}\"; do\n    total_pg_slow_active_count=$((total_pg_slow_active_count + count))\n  done\n\n  echo \"$(date): total pg_slow_active_count: $total_pg_slow_active_count\"\n\n  if [[ \"$total_pg_slow_active_count\" == 0 ]]; then\n    # pause pgbouncer on all pgb_servers. We send via ssh to all pgbouncers in parallel and collect results from all (maximum wait time 2 seconds)\n    IFS=$'\\n' pause_results=($(echo -e \"$pgb_servers\" | xargs -I {} -P \"$pgb_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"$pgb_pause_command 2>&1 || true\"))\n    echo \"${pause_results[*]}\"\n    # analyze the pause_results array to count the number of paused pgbouncers\n    pgb_paused_count=$(echo \"${pause_results[*]}\" | grep -o -e \"PAUSE\" -e \"already suspended/paused\" | wc -l)\n    echo \"$(date): pgb_count: $pgb_count, pgb_paused: $pgb_paused_count\"\n  fi\n\n  # make sure that the pause is performed on all pgbouncer servers, to ensure atomicity\n  if [[ \"$pgb_paused_count\" -eq \"$pgb_count\" ]]; then\n    break # pause is performed on all pgb_servers, exit from the loop\n  elif [[ \"$pgb_paused_count\" -gt 0 && \"$pgb_paused_count\" -ne \"$pgb_count\" ]]; then\n    # pause is not performed on all pgb_servers, perform resume (we do not use timeout because we mast to resume all pgbouncers)\n    IFS=$'\\n' resume_results=($(echo -e \"$pgb_servers\" | xargs -I {} -P \"$pgb_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"$pgb_resume_command 2>&1 || true\"))\n    echo \"${resume_results[*]}\"\n  fi\n\n  # after 30 seconds of waiting, terminate active sessions on pg_servers and try pausing again\n  if (( current_time - start_time >= 30 )); then\n    echo \"$(date): terminate active queries\"\n    echo -e \"$pg_servers\" | xargs -I {} -P \"$pg_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"PGPASSWORD='x8ivlzqOMhURoK7xUk8tVWxFOdJLdES0' psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -tAXc \\\"$pg_slow_active_terminate_query\\\"\"\n  fi\n\n  # if it was not possible to pause for 60 seconds, exit with an error\n  if (( current_time - start_time >= 60 )); then\n    echo \"$(date): it was not possible to pause (exit by timeout)\"\n    exit 1\n  fi\ndone > /tmp/pgbouncer_pool_pause_2025-08-30.log\n", "delta": "0:01:01.242759", "end": "2025-08-30 00:44:58.562258", "msg": "non-zero return code", "rc": 1, "start": "2025-08-30 00:43:57.319499", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
  
  TASK [vitabaks.autobase.upgrade : PAUSE PgBouncer pools] ***********************
  ...ignoring
```