### PR TITLE
Use sysctl_file option for ansible.posix.sysctl module

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -852,7 +852,7 @@ swap_file_size_mb: "4096" # change this value for your system
 
 # Kernel parameters
 sysctl_set: true # or 'false'
-sysctl_file: /etc/sysctl.d/autobase.conf
+sysctl_file: /etc/sysctl.d/autobase.sysctl.conf
 sysctl_conf:
   etcd_cluster: []
   consul_instances: []

--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -852,7 +852,7 @@ swap_file_size_mb: "4096" # change this value for your system
 
 # Kernel parameters
 sysctl_set: true # or 'false'
-# these parameters for example! Specify kernel options for your system
+sysctl_file: /etc/sysctl.d/autobase.conf
 sysctl_conf:
   etcd_cluster: []
   consul_instances: []

--- a/automation/roles/sysctl/tasks/main.yml
+++ b/automation/roles/sysctl/tasks/main.yml
@@ -14,7 +14,7 @@
         value: "{{ item.value }}"
         sysctl_set: true
         state: present
-        sysctl_file: "{{ sysctl_file | default('/etc/sysctl.d/autobase.conf') }}"
+        sysctl_file: "{{ sysctl_file | default('/etc/sysctl.d/autobase.sysctl.conf') }}"
         reload: true
       loop: "{{ sysctl_conf_dynamic_var | default([]) | unique }}"
       when: sysctl_conf_dynamic_var | default([]) | length > 0

--- a/automation/roles/sysctl/tasks/main.yml
+++ b/automation/roles/sysctl/tasks/main.yml
@@ -14,9 +14,10 @@
         value: "{{ item.value }}"
         sysctl_set: true
         state: present
+        sysctl_file: "{{ sysctl_file | default('/etc/sysctl.d/autobase.conf') }}"
         reload: true
       loop: "{{ sysctl_conf_dynamic_var | default([]) | unique }}"
       when: sysctl_conf_dynamic_var | default([]) | length > 0
   ignore_errors: true
-  when: sysctl_set|bool
+  when: sysctl_set | bool
   tags: sysctl, kernel


### PR DESCRIPTION
Issue: https://github.com/vitabaks/autobase/issues/1257

New variable: `sysctl_file`, default: `/etc/sysctl.d/autobase.sysctl.conf`