### PR TITLE
Update default locale to en_US.UTF-8

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -878,7 +878,7 @@ locale_gen:
 #  - { language_country: "", encoding: "" }
 
 # Set system locale (LANG,LC_ALL)
-locale: "en_US.utf-8"
+locale: "en_US.UTF-8"
 
 # Configure swap space
 swap_file_create: true # or 'false'


### PR DESCRIPTION
The correct name of locale is en_US.UTF-8.

Resolves: #1262