### PR TITLE
formatting: Update connection string for target_session_attrs

### DIFF
--- a/automation/roles/deploy_finish/tasks/main.yml
+++ b/automation/roles/deploy_finish/tasks/main.yml
@@ -157,8 +157,8 @@
           superuser: "{{ superuser_username }}"
           password: "{{ superuser_password }}"
           connection_string:
-            read_write: "postgresql://{{ superuser_username }}:{{ superuser_password }}@{{ libpq_postgres_host_port }}/postgres?target_session_attrs=read-write"
-            read_only: "postgresql://{{ superuser_username }}:{{ superuser_password }}@{{ libpq_postgres_host_port }}/postgres?target_session_attrs=read-only{{ libpq_load_balance }}"
+            read_write: "postgresql://{{ superuser_username }}@{{ libpq_postgres_host_port }}/postgres?target_session_attrs=read-write"
+            read_only: "postgresql://{{ superuser_username }}@{{ libpq_postgres_host_port }}/postgres?target_session_attrs=read-only{{ libpq_load_balance }}"
       when: not with_haproxy_load_balancing | bool and not pgbouncer_install | bool
   ignore_errors: true
   vars:
@@ -178,7 +178,7 @@
       }}
     superuser_username: "{{ patroni_superuser_username }}"
     superuser_password: "{{ '********' if mask_password | default(false) | bool else patroni_superuser_password }}"
-    libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(', ') }}"
+    libpq_postgres_host_port: "{{ postgres_ip_addresses.split(',') | map('regex_replace', '$', ':' + postgresql_port | string) | join(',') }}"
     libpq_load_balance: "{{ '&load_balance_hosts=random' if postgresql_version | int >= 16 else '' }}"
   when:
     - (cluster_vip is not defined or cluster_vip | length < 1)


### PR DESCRIPTION
Updated the join operation for libpq_postgres_host_port to use ',' instead of ', ' to ensure the resulting string does not contain spaces after commas.

The password has been removed from the connection string, which makes sense — once the password is masked, the connection string becomes invalid.