### PR TITLE
fix: prevent always regenerating TLS certificates in config_pgcluster

### DIFF
--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -129,7 +129,6 @@
             name: vitabaks.autobase.tls_certificate
           vars:
             tls_group_name: "postgres_cluster"
-            tls_cert_regenerate: true
 
         - name: Copy Postgres TLS certificate, key and CA to all nodes
           ansible.builtin.include_role:


### PR DESCRIPTION
Fixed certificate regeneration by removing forced tls_cert_regenerate: true from include_role vars, so certificates are now regenerated only when tls_cert_regenerate is explicitly set.

Related PR: https://github.com/vitabaks/autobase/pull/1235