### PR TITLE
Add cluster scaling support for cloud providers

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -289,22 +289,21 @@
     - role: vitabaks.autobase.pgbackrest
       when: pgbackrest_install | bool
 
-- name: vitabaks.autobase.add_node | Add new PostgreSQL replica to the cluster
-  hosts: new_replica
+- name: vitabaks.autobase.add_node | Regenerate Postgres TLS certificates
+  hosts: postgres_cluster
   become: true
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
   vars:
     cluster_scaling: true
-
-  pre_tasks:
+  tasks:
     - name: Generate Postgres TLS certificate
       ansible.builtin.include_role:
         name: vitabaks.autobase.tls_certificate
       vars:
         tls_group_name: "postgres_cluster"
-        tls_cert_regenerate: true  # Regenerate when adding nodes
+        tls_cert_regenerate: true
       when: tls_cert_generate | default(true) | bool
 
     - name: Copy Postgres TLS certificate, key and CA to all nodes
@@ -313,6 +312,14 @@
         tasks_from: copy
       when: tls_cert_generate | default(true) | bool
 
+- name: vitabaks.autobase.add_node | Add new PostgreSQL replica to the cluster
+  hosts: new_replica
+  become: true
+  become_method: sudo
+  gather_facts: true
+  any_errors_fatal: true
+  vars:
+    cluster_scaling: true
   roles:
     - role: vitabaks.autobase.wal_g
       when: wal_g_install | default(false) | bool

--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -1,5 +1,29 @@
 ---
 - name: vitabaks.autobase.add_node | PostgreSQL HA Cluster Scaling (add a new node)
+  hosts: localhost
+  gather_facts: true
+  any_errors_fatal: true
+  pre_tasks:
+    # set_fact: 'pgbackrest_install' to configure Postgres backups (TODO: Add the ability to configure backups in the UI)
+    # Note: Applicable only for "aws", "gcp", "azure", because:
+    # "digitalocean" - requires the Spaces access keys ("AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" variables)
+    # "hetzner" - requires the S3 credentials ("hetzner_object_storage_access_key" and "hetzner_object_storage_secret_key" variables).
+    - name: "Set variable: 'pgbackrest_install' to configure Postgres backups"
+      ansible.builtin.set_fact:
+        pgbackrest_install: true
+      when:
+        - not (pgbackrest_install | default(false) | bool or wal_g_install | default(false) | bool)
+        - cloud_provider | default('') | lower in ['aws', 'gcp', 'azure']
+        - pgbackrest_auto_conf | default(true) | bool # to be able to disable auto backup settings
+      tags: always
+  roles:
+    - role: vitabaks.autobase.cloud_resources
+      when: cloud_provider | default('') | length > 0
+      vars:
+        cluster_scaling: true
+      tags: always
+
+- name: vitabaks.autobase.add_node | Prepare and perform pre-checks
   hosts: postgres_cluster:etcd_cluster:consul_instances:balancers
   become: true
   become_method: sudo

--- a/automation/requirements.yml
+++ b/automation/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - name: google.cloud
     version: ">=1.7.0"
   - name: azure.azcollection
-    version: ">=3.7.0"
+    version: ">=3.8.0"
   - name: community.digitalocean
     version: ">=1.27.0"
   - name: hetzner.hcloud

--- a/automation/requirements.yml
+++ b/automation/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: amazon.aws
-    version: ">=10.1.0"
+    version: ">=10.1.1"
   - name: community.aws
     version: ">=10.0.0"
   - name: google.cloud

--- a/automation/requirements.yml
+++ b/automation/requirements.yml
@@ -5,7 +5,7 @@ collections:
   - name: community.aws
     version: ">=10.0.0"
   - name: google.cloud
-    version: ">=1.7.0"
+    version: ">=1.8.0"
   - name: azure.azcollection
     version: ">=3.8.0"
   - name: community.digitalocean

--- a/automation/requirements.yml
+++ b/automation/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: community.digitalocean
     version: ">=1.27.0"
   - name: hetzner.hcloud
-    version: ">=5.1.0"
+    version: ">=5.2.0"
   - name: community.postgresql
     version: ">=3.14.2"
   - name: community.docker

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -569,18 +569,21 @@
             [{
               'public_ip': item.instances[0].public_ip_address | default(''),
               'private_ip': item.instances[0].private_ip_address | default(''),
-              'new_node': (cluster_scaling | default(false) | bool and instance_info.results[idx].instances | length == 0)
+              'new_node': (cluster_scaling | default(false) | bool and item.instances[0].instance_id not in existing_instance_ids)
             }]
           }}
       vars:
-        instance_info: >-
+        existing_instance_ids: >-
           {{
-            (server_spot | default(aws_ec2_spot_instance | default(false)) | bool)
-            | ternary(ec2_spot_instance_info, ec2_instance_info)
+            (
+              (ec2_instance_info.results | default([])) +
+              (ec2_spot_instance_info.results | default([]))
+            )
+            | selectattr('instances','defined') | map(attribute='instances') | list | flatten
+            | selectattr('instance_id','defined') | map(attribute='instance_id') | list
           }}
       loop: "{{ server_result.results | selectattr('instances', 'defined') }}"
       loop_control:
-        index_var: idx
         label: >-
           public_ip: {{ item.instances[0].public_ip_address | default('') }},
           private_ip: {{ item.instances[0].private_ip_address | default('') }}

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -288,8 +288,8 @@
             label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
           register: server_result
           until:
-            - server_result.instances[0][ip_address_type] is defined
-            - server_result.instances[0][ip_address_type] | length > 0
+            - (server_result.instances[0][ip_address_type] | default('')) | length > 0
+            - (server_result.instances[0].state.name | default('')) == 'running'
           retries: 3
           delay: 10
           when: ec2_instance_info.results[idx].instances | length == 0 # only if instance does not exist

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -261,7 +261,7 @@
             access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
             secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
             name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-            state: present
+            state: running
             instance_type: "{{ server_type }}"
             image_id: "{{ server_image }}"
             key_name: "{{ ssh_key_name }}"
@@ -287,9 +287,6 @@
             index_var: idx
             label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
           register: ec2_instance_result
-          until:
-            - (ec2_instance_result.instances[0][ip_address_type] | default('')) | length > 0
-            - (ec2_instance_result.instances[0].state.name | default('')) == 'running'
           retries: 3
           delay: 10
           when: ec2_instance_info.results[idx].instances | length == 0 # only if instance does not exist

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -256,7 +256,7 @@
             label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
           register: ec2_instance_info
 
-        - name: "AWS: Create or modify EC2 instance"
+        - name: "AWS: Create EC2 instance"
           amazon.aws.ec2_instance:
             access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
             secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
@@ -292,6 +292,7 @@
             - server_result.instances[0][ip_address_type] | length > 0
           retries: 3
           delay: 10
+          when: ec2_instance_info.results[idx].instances | length == 0 # only if instance does not exist
       when: not server_spot | default(aws_ec2_spot_instance | default(false)) | bool
 
     # Spot instance (if 'server_spot' is 'true')
@@ -417,13 +418,26 @@
       loop_control:
         label: "{{ patroni_cluster_name }}-{{ item }}"
       register: aws_elb_classic_lb
-      when: cloud_load_balancer | bool and aws_load_balancer_type | lower == 'clb' and
+      when: server_result.results | default([]) | length > 0 and
+        cloud_load_balancer | bool and aws_load_balancer_type | lower == 'clb' and
         (item == 'primary' or
         (item == 'replica' and server_count | int > 1) or
         (item in ['sync', 'async'] and server_count | int > 1 and synchronous_mode | bool))
 
     # Network Load Balancer (NLB)
-    - name: "AWS: Create NLB Target Group"
+    - name: Build NLB targets
+      ansible.builtin.set_fact:
+        nlb_targets: "{{ (nlb_targets | default([])) + [ {'Id': item, 'Port': target_port | int} ] }}"
+      loop: "{{ instance_ids | default([]) }}"
+      vars:
+        existing_ids: "{{ (ec2_instance_info | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
+        existing_spot_ids: "{{ (ec2_spot_instance_info | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
+        created_ids: "{{ (server_result | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
+        instance_ids: "{{ (existing_ids + existing_spot_ids + created_ids) | unique | list }}"
+        target_port: "{{ pgbouncer_listen_port | default('6432') if pgbouncer_install | bool else postgresql_port | default('5432') }}"
+      when: cloud_load_balancer | bool and aws_load_balancer_type | lower == 'nlb'
+
+    - name: "AWS: Create or modify NLB Target Group"
       community.aws.elb_target_group:
         access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
         secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
@@ -442,16 +456,7 @@
         healthy_threshold_count: 3
         successful_response_codes: "200"
         target_type: instance
-        targets: >-
-          {{
-            server_result.results
-            | map(attribute='instances')
-            | map('first')
-            | map(attribute='instance_id')
-            | map('community.general.dict_kv', 'Id')
-            | map('combine', {'Port': target_port | int})
-            | list
-          }}
+        targets: "{{ nlb_targets | default([]) }}"
         modify_targets: true
         wait: false
         state: present
@@ -529,7 +534,7 @@
       volume_size: "{{ volume_size }} GB"
       public_ip: "{{ item.instances[0].public_ip_address | default('N/A', true) }}"
       private_ip: "{{ item.instances[0].private_ip_address | default('N/A', true) }}"
-  loop: "{{ server_result.results }}"
+  loop: "{{ server_result.results | default([]) }}"
   loop_control:
     index_var: idx
     label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
@@ -544,7 +549,7 @@
     port: 22
     delay: 5
     timeout: 300
-  loop: "{{ server_result.results }}"
+  loop: "{{ server_result.results | default([]) }}"
   loop_control:
     index_var: idx
     label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -282,6 +282,9 @@
                   volume_type: "{{ volume_type | default('gp3', true) }}"
                   volume_size: "{{ volume_size | int }}"
                   delete_on_termination: true
+            tags:
+              Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+              Cluster: "{{ patroni_cluster_name }}"
           loop: "{{ range(0, server_count | int) | list }}"
           loop_control:
             index_var: idx
@@ -340,6 +343,7 @@
                     delete_on_termination: true
             tags:
               Name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+              Cluster: "{{ patroni_cluster_name }}"
           loop: "{{ ec2_spot_instance_info.results }}"
           loop_control:
             index_var: idx

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -561,7 +561,7 @@
             [{
               'public_ip': item.instances[0].public_ip_address | default(''),
               'private_ip': item.instances[0].private_ip_address | default(''),
-              'new_node': (instance_info.results[idx].instances | length == 0)
+              'new_node': (cluster_scaling | default(false) | bool and instance_info.results[idx].instances | length == 0)
             }]
           }}
       vars:

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -433,7 +433,7 @@
     # Network Load Balancer (NLB)
     - name: Build NLB targets
       ansible.builtin.set_fact:
-        nlb_targets: "{{ (nlb_targets | default([])) + [ {'Id': item, 'Port': target_port | int} ] }}"
+        nlb_targets: "{{ (nlb_targets | default([])) + [{'Id': item, 'Port': target_port | int}] }}"
       loop: "{{ instance_ids | default([]) }}"
       vars:
         instance_ids: "{{ (server_result | default({'results': []})) | json_query('results[].instances[].instance_id') }}"

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -240,42 +240,58 @@
         ip_address_type: "{{ 'public_ip_address' if server_public_ip | bool else 'private_ip_address' }}"
 
     # Server and volume
-    - name: "AWS: Create or modify EC2 instance"
-      amazon.aws.ec2_instance:
-        access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
-        secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
-        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-        state: present
-        instance_type: "{{ server_type }}"
-        image_id: "{{ server_image }}"
-        key_name: "{{ ssh_key_name }}"
-        region: "{{ server_location }}"
-        network_interfaces:
-          - subnet_id: "{{ server_network }}"
-            groups: "{{ ([] if not cloud_firewall | bool else [ec2_security_group_result.group_id]) }}"
-            assign_public_ip: "{{ server_public_ip | bool }}"
-            delete_on_termination: true
-        volumes:
-          - device_name: /dev/sda1
-            ebs:
-              volume_type: "{{ system_volume_type | default('gp3', true) }}"
-              volume_size: "{{ system_volume_size | default(80) | int }}"
-              delete_on_termination: true
-          - device_name: /dev/sdb
-            ebs:
-              volume_type: "{{ volume_type | default('gp3', true) }}"
-              volume_size: "{{ volume_size | int }}"
-              delete_on_termination: true
-      loop: "{{ range(0, server_count | int) | list }}"
-      loop_control:
-        index_var: idx
-        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-      register: server_result
-      until:
-        - server_result.instances[0][ip_address_type] is defined
-        - server_result.instances[0][ip_address_type] | length > 0
-      retries: 3
-      delay: 10
+    - block:
+        - name: "AWS: Gather information about EC2 instances"
+          amazon.aws.ec2_instance_info:
+            access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
+            secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
+            region: "{{ server_location }}"
+            filters:
+              instance-type: "{{ server_type }}"
+              instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]
+              "tag:Name": "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+          loop: "{{ range(0, server_count | int) | list }}"
+          loop_control:
+            index_var: idx
+            label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+          register: ec2_instance_info
+
+        - name: "AWS: Create or modify EC2 instance"
+          amazon.aws.ec2_instance:
+            access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
+            secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
+            name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+            state: present
+            instance_type: "{{ server_type }}"
+            image_id: "{{ server_image }}"
+            key_name: "{{ ssh_key_name }}"
+            region: "{{ server_location }}"
+            network_interfaces:
+              - subnet_id: "{{ server_network }}"
+                groups: "{{ ([] if not cloud_firewall | bool else [ec2_security_group_result.group_id]) }}"
+                assign_public_ip: "{{ server_public_ip | bool }}"
+                delete_on_termination: true
+            volumes:
+              - device_name: /dev/sda1
+                ebs:
+                  volume_type: "{{ system_volume_type | default('gp3', true) }}"
+                  volume_size: "{{ system_volume_size | default(80) | int }}"
+                  delete_on_termination: true
+              - device_name: /dev/sdb
+                ebs:
+                  volume_type: "{{ volume_type | default('gp3', true) }}"
+                  volume_size: "{{ volume_size | int }}"
+                  delete_on_termination: true
+          loop: "{{ range(0, server_count | int) | list }}"
+          loop_control:
+            index_var: idx
+            label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+          register: server_result
+          until:
+            - server_result.instances[0][ip_address_type] is defined
+            - server_result.instances[0][ip_address_type] | length > 0
+          retries: 3
+          delay: 10
       when: not server_spot | default(aws_ec2_spot_instance | default(false)) | bool
 
     # Spot instance (if 'server_spot' is 'true')
@@ -288,7 +304,6 @@
             filters:
               instance-lifecycle: "spot"
               instance-type: "{{ server_type }}"
-              image-id: "{{ server_image }}"
               instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]
               "tag:Name": "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
           loop: "{{ range(0, server_count | int) | list }}"
@@ -545,11 +560,19 @@
           {{ ip_addresses | default([]) +
             [{
               'public_ip': item.instances[0].public_ip_address | default(''),
-              'private_ip': item.instances[0].private_ip_address | default('')
+              'private_ip': item.instances[0].private_ip_address | default(''),
+              'new_node': (instance_info.results[idx].instances | length == 0)
             }]
+          }}
+      vars:
+        instance_info: >-
+          {{
+            (server_spot | default(aws_ec2_spot_instance | default(false)) | bool)
+            | ternary(ec2_spot_instance_info, ec2_instance_info)
           }}
       loop: "{{ server_result.results | selectattr('instances', 'defined') }}"
       loop_control:
+        index_var: idx
         label: >-
           public_ip: {{ item.instances[0].public_ip_address | default('') }},
           private_ip: {{ item.instances[0].private_ip_address | default('') }}

--- a/automation/roles/cloud_resources/tasks/aws.yml
+++ b/automation/roles/cloud_resources/tasks/aws.yml
@@ -286,10 +286,10 @@
           loop_control:
             index_var: idx
             label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-          register: server_result
+          register: ec2_instance_result
           until:
-            - (server_result.instances[0][ip_address_type] | default('')) | length > 0
-            - (server_result.instances[0].state.name | default('')) == 'running'
+            - (ec2_instance_result.instances[0][ip_address_type] | default('')) | length > 0
+            - (ec2_instance_result.instances[0].state.name | default('')) == 'running'
           retries: 3
           delay: 10
           when: ec2_instance_info.results[idx].instances | length == 0 # only if instance does not exist
@@ -369,19 +369,24 @@
           retries: 3
           delay: 10
           when: item.spot_request.spot_instance_request_id is defined
-
-        # if spot instances are created now
-        - name: "Set variable: server_result"
-          ansible.builtin.set_fact:
-            server_result: "{{ ec2_spot_instance_result }}"
-          when: ec2_spot_instance_result.changed | default(false)
-
-        # if spot instances have already been created
-        - name: "Set variable: server_result"
-          ansible.builtin.set_fact:
-            server_result: "{{ ec2_spot_instance_info }}"
-          when: not ec2_spot_instance_result.changed | default(false)
       when: server_spot | default(aws_ec2_spot_instance | default(false)) | bool
+
+    # Combine existing and newly created instances
+    - name: "Set variable: server_result"
+      ansible.builtin.set_fact:
+        server_result:
+          results: >-
+            {{
+              (
+                (ec2_instance_info.results | default([]))
+                + (ec2_instance_result.results | default([]))
+                + (ec2_spot_instance_info.results | default([]))
+                + (ec2_spot_instance_result.results | default([]))
+              )
+              | selectattr('instances', 'defined')
+              | selectattr('instances', '!=', [])
+              | list
+            }}
 
     # Classic Load Balancer (CLB) - previous generation
     - name: "AWS: Create Classic Load Balancer (CLB)"
@@ -430,10 +435,7 @@
         nlb_targets: "{{ (nlb_targets | default([])) + [ {'Id': item, 'Port': target_port | int} ] }}"
       loop: "{{ instance_ids | default([]) }}"
       vars:
-        existing_ids: "{{ (ec2_instance_info | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
-        existing_spot_ids: "{{ (ec2_spot_instance_info | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
-        created_ids: "{{ (server_result | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
-        instance_ids: "{{ (existing_ids + existing_spot_ids + created_ids) | unique | list }}"
+        instance_ids: "{{ (server_result | default({'results': []})) | json_query('results[].instances[].instance_id') }}"
         target_port: "{{ pgbouncer_listen_port | default('6432') if pgbouncer_install | bool else postgresql_port | default('5432') }}"
       when: cloud_load_balancer | bool and aws_load_balancer_type | lower == 'nlb'
 

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -94,13 +94,13 @@
         - name: Install Azure CLI
           ansible.builtin.shell: >
             set -o pipefail;
-            curl -sL https://aka.ms/InstallAzureCli | bash
+            curl -sL https://aka.ms/InstallAzureCLIDeb | bash
           args:
             executable: /bin/bash
           ignore_errors: true
           when:
             - az_version_result.rc != 0
-            - ansible_distribution != "MacOSX"
+            - ansible_os_family == "Debian"
 
         # login
         - name: Login to Azure using Service Principal
@@ -111,6 +111,7 @@
             --tenant "{{ lookup('env', 'AZURE_TENANT') }}"
           args:
             executable: /bin/bash
+          changed_when: false
       when: cloud_load_balancer | bool
   delegate_to: 127.0.0.1
   become: false

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -348,7 +348,7 @@
           - name: "{{ patroni_cluster_name }}-{{ item }}-backend"
         probes:
           - name: "{{ patroni_cluster_name }}-{{ item }}-health-probe"
-            protocol: "Http"
+            protocol: "{{ patroni_restapi_protocol | capitalize }}"
             port: "{{ patroni_restapi_port }}"
             request_path: "/{{ item }}"
             interval: 5

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -310,6 +310,8 @@
             managed_disk_type: "{{ volume_type | default('StandardSSD_LRS', true) }}"
         network_interface_names:
           - "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-network-interface"
+        tags:
+          Cluster: "{{ patroni_cluster_name }}"
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx

--- a/automation/roles/cloud_resources/tasks/azure.yml
+++ b/automation/roles/cloud_resources/tasks/azure.yml
@@ -269,6 +269,17 @@
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}-network-interface"
 
     # Server and volume
+    - name: "Azure: Gather information about virtual machines"
+      azure.azcollection.azure_rm_virtualmachine_info:
+        resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
+        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      loop: "{{ range(0, server_count | int) | list }}"
+      loop_control:
+        index_var: idx
+        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      register: azure_rm_virtualmachine_info
+      failed_when: false
+
     - name: "Azure: Create virtual machine"
       azure.azcollection.azure_rm_virtualmachine:
         resource_group: "{{ azure_resource_group | default('postgres-cluster-resource-group' ~ '-' ~ server_location) }}"
@@ -505,8 +516,16 @@
           {{ ip_addresses | default([]) +
             [{
               'public_ip': (public_ip_address.results if public_ip_address is defined else []) | selectattr('idx', 'equalto', item.idx) | map(attribute='state.ip_address') | first | default(''),
-              'private_ip': item.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address | default('')
+              'private_ip': item.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address | default(''),
+              'new_node': (cluster_scaling | default(false) | bool and item.ansible_facts.azure_vm.id not in existing_vm_ids)
             }]
+          }}
+      vars:
+        existing_vm_ids: >-
+          {{
+            azure_rm_virtualmachine_info.results | default([])
+            | map(attribute='vms') | map('default', []) | list | flatten
+            | selectattr('id','defined') | map(attribute='id') | list
           }}
       loop: "{{ server_result.results | selectattr('ansible_facts.azure_vm', 'defined') }}"
       loop_control:

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -586,7 +586,7 @@
             target_protocol: tcp
             target_port: "{{ digital_ocean_load_balancer_target_port }}"
         health_check:
-          protocol: http
+          protocol: "{{ patroni_restapi_protocol }}"
           port: "{{ patroni_restapi_port }}"
           path: "/{{ item }}"
           check_interval_seconds: 5

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -215,6 +215,8 @@
         state: present
 
     # Firewall
+    # Note: digital_ocean_droplet module doesn't support disabling public IP,
+    # but we do not open public SSH in Firewall and use private IP if server_public_ip: false
     - name: "DigitalOcean: Create or modify public firewall"
       community.digitalocean.digital_ocean_firewall:
         oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
@@ -479,8 +481,16 @@
       when: cloud_firewall | bool
 
     # Server and volume
-    # Note: module doesn't support disabling public IP,
-    # but we do not open public SSH in Firewall and use private IP if server_public_ip: false
+    - name: "DigitalOcean: Gather information about Droplets"
+      community.digitalocean.digital_ocean_droplet_info:
+        oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      loop: "{{ range(0, server_count | int) | list }}"
+      loop_control:
+        index_var: idx
+        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      register: digital_ocean_droplet_info
+
     - name: "DigitalOcean: Create or modify Droplet"
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
@@ -665,8 +675,16 @@
           {{ ip_addresses | default([]) +
             [{
               'public_ip': (item.data.droplet.networks.v4 | selectattr('type', 'equalto', 'public')).0.ip_address | default(''),
-              'private_ip': (item.data.droplet.networks.v4 | selectattr('type', 'equalto', 'private')).0.ip_address | default('')
+              'private_ip': (item.data.droplet.networks.v4 | selectattr('type', 'equalto', 'private')).0.ip_address | default(''),
+              'new_node': (cluster_scaling | default(false) | bool and item.data.droplet.id not in existing_droplet_ids)
             }]
+          }}
+      vars:
+        existing_droplet_ids: >-
+          {{
+            digital_ocean_droplet_info.results | default([])
+            | map(attribute='data') | map('default', []) | list | flatten
+            | selectattr('id','defined') | map(attribute='id') | list
           }}
       loop: "{{ droplet_result.results | selectattr('data', 'defined') }}"
       loop_control:

--- a/automation/roles/cloud_resources/tasks/digitalocean.yml
+++ b/automation/roles/cloud_resources/tasks/digitalocean.yml
@@ -490,6 +490,7 @@
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
       register: digital_ocean_droplet_info
+      failed_when: false
 
     - name: "DigitalOcean: Create or modify Droplet"
       community.digitalocean.digital_ocean_droplet:

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -305,7 +305,7 @@
           items:
             - "{{ patroni_cluster_name }}"
         labels:
-          cluster: "{{ patroni_cluster_name }}"
+          Cluster: "{{ patroni_cluster_name }}"
         status: "{{ gcp_instance_status | default('RUNNING') }}"
         state: present
       loop: "{{ range(0, server_count | int) | list }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -381,7 +381,7 @@
             project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
             name: "{{ patroni_cluster_name }}-{{ item }}-hc"
             description: "{{ patroni_cluster_name }} {{ item }} health check"
-            type: "HTTP"
+            type: "{{ patroni_restapi_protocol | upper }}"
             http_health_check:
               port: "{{ patroni_restapi_port }}"
               request_path: "/{{ item }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -269,7 +269,7 @@
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
       register: gcp_compute_instance_info
 
-    - name: "GCP: Create VM instance"
+    - name: "GCP: Create or modify VM instance"
       google.cloud.gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -365,9 +365,10 @@
             name: "{{ patroni_cluster_name }}-{{ item }}-hc"
             description: "{{ patroni_cluster_name }} {{ item }} health check"
             type: "{{ patroni_restapi_protocol | upper }}"
-            http_health_check:
-              port: "{{ patroni_restapi_port }}"
-              request_path: "/{{ item }}"
+            http_health_check: "{{ ({'port': patroni_restapi_port|int, 'request_path': '/' ~ item})
+              if (patroni_restapi_protocol | lower) == 'http' else omit }}"
+            https_health_check: "{{ ({'port': patroni_restapi_port|int, 'request_path': '/' ~ item})
+              if (patroni_restapi_protocol | lower) == 'https' else omit }}"
             check_interval_sec: "{{ gcp_compute_health_check_interval_sec | default(3) }}"
             timeout_sec: "{{ gcp_compute_health_check_check_timeout_sec | default(2) }}"
             unhealthy_threshold: "{{ gcp_compute_health_check_unhealthy_threshold | default(2) }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -316,7 +316,7 @@
       until: gcp_compute_instance_result is success
       delay: 10
       retries: 3
-      when: gcp_compute_instance_info.results[idx].id | length == 0 # only if instance does not exist
+      when: gcp_compute_instance_info.results[idx].resources | length == 0 # only if instance does not exist
 
     # Combine existing and newly created instances
     - name: "Set variable: server_result"
@@ -325,7 +325,7 @@
           results: >-
             {{
               (
-                (gcp_compute_instance_info.results | default([]))
+                (gcp_compute_instance_info.results.resources | default([]))
                 + (gcp_compute_instance_result.results | default([]))
               )
               | selectattr('instances', 'defined')
@@ -563,7 +563,7 @@
             [{
               'public_ip': item.networkInterfaces[0].accessConfigs[0].natIP | default(''),
               'private_ip': item.networkInterfaces[0].networkIP | default(''),
-              'new_node': (cluster_scaling | default(false) | bool and gcp_compute_instance_info.results[idx].id | length == 0)
+              'new_node': (cluster_scaling | default(false) | bool and gcp_compute_instance_info.results[idx].resources | length == 0)
             }]
           }}
       loop: "{{ server_result.results | selectattr('networkInterfaces', 'defined') }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -255,7 +255,21 @@
       when: cloud_load_balancer | bool
 
     # Server and volume
-    - name: "GCP: Create or modify VM instance"
+    - name: "GCP: Gather information about VM instances"
+      google.cloud.gcp_compute_instance_info:
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ gcp_service_account_contents }}"
+        project: "{{ gcp_project | default(project_info.resources[0].projectNumber) }}"
+        zone: "{{ server_location + '-b' if not server_location is match('.*-[a-z]$') else server_location }}" # add "-b" if the zone is not defined
+        filters:
+          - "name = {{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      loop: "{{ range(0, server_count | int) | list }}"
+      loop_control:
+        index_var: idx
+        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      register: gcp_compute_instance_info
+
+    - name: "GCP: Create VM instance"
       google.cloud.gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_contents: "{{ gcp_service_account_contents }}"
@@ -298,10 +312,26 @@
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-      register: server_result
-      until: server_result is success
+      register: gcp_compute_instance_result
+      until: gcp_compute_instance_result is success
       delay: 10
       retries: 3
+      when: gcp_compute_instance_info.results[idx].id | length == 0 # only if instance does not exist
+
+    # Combine existing and newly created instances
+    - name: "Set variable: server_result"
+      ansible.builtin.set_fact:
+        server_result:
+          results: >-
+            {{
+              (
+                (gcp_compute_instance_info.results | default([]))
+                + (gcp_compute_instance_result.results | default([]))
+              )
+              | selectattr('instances', 'defined')
+              | selectattr('instances', '!=', [])
+              | list
+            }}
 
     # Load Balancer
     # This block creates Global External classic proxy Network Load Balancer.
@@ -532,7 +562,8 @@
           {{ ip_addresses | default([]) +
             [{
               'public_ip': item.networkInterfaces[0].accessConfigs[0].natIP | default(''),
-              'private_ip': item.networkInterfaces[0].networkIP | default('')
+              'private_ip': item.networkInterfaces[0].networkIP | default(''),
+              'new_node': (cluster_scaling | default(false) | bool and gcp_compute_instance_info.results[idx].id | length == 0)
             }]
           }}
       loop: "{{ server_result.results | selectattr('networkInterfaces', 'defined') }}"

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -569,6 +569,7 @@
           }}
       loop: "{{ server_result.results | selectattr('networkInterfaces', 'defined') }}"
       loop_control:
+        index_var: idx
         label: >-
           public_ip: {{ item.networkInterfaces[0].accessConfigs[0].natIP | default('') }},
           private_ip: {{ item.networkInterfaces[0].networkIP | default('') }}

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -325,11 +325,10 @@
           results: >-
             {{
               (
-                (gcp_compute_instance_info.results.resources | default([]))
+                (gcp_compute_instance_info.results | default([]) | map(attribute='resources') | select('defined') | list | flatten)
                 + (gcp_compute_instance_result.results | default([]))
               )
-              | selectattr('instances', 'defined')
-              | selectattr('instances', '!=', [])
+              | selectattr('id', 'defined')
               | list
             }}
 

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -564,12 +564,18 @@
             [{
               'public_ip': item.networkInterfaces[0].accessConfigs[0].natIP | default(''),
               'private_ip': item.networkInterfaces[0].networkIP | default(''),
-              'new_node': (cluster_scaling | default(false) | bool and gcp_compute_instance_info.results[idx].resources | length == 0)
+              'new_node': (cluster_scaling | default(false) | bool and item.id not in existing_instance_ids)
             }]
+          }}
+      vars:
+        existing_instance_ids: >-
+          {{
+            gcp_compute_instance_info.results | default([])
+            | map(attribute='resources') | map('default', []) | list | flatten
+            | selectattr('id','defined') | map(attribute='id') | list
           }}
       loop: "{{ server_result.results | selectattr('networkInterfaces', 'defined') }}"
       loop_control:
-        index_var: idx
         label: >-
           public_ip: {{ item.networkInterfaces[0].accessConfigs[0].natIP | default('') }},
           private_ip: {{ item.networkInterfaces[0].networkIP | default('') }}

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -305,34 +305,17 @@
           items:
             - "{{ patroni_cluster_name }}"
         labels:
-          Cluster: "{{ patroni_cluster_name }}"
+          cluster: "{{ patroni_cluster_name }}"
         status: "{{ gcp_instance_status | default('RUNNING') }}"
         state: present
       loop: "{{ range(0, server_count | int) | list }}"
       loop_control:
         index_var: idx
         label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
-      register: gcp_compute_instance_result
-      until: gcp_compute_instance_result is success
+      register: server_result
+      until: server_result is success
       delay: 10
       retries: 3
-      when: gcp_compute_instance_info.results[idx].resources | length == 0 # only if instance does not exist
-
-    # Combine existing and newly created instances
-    - name: "Set variable: server_result"
-      ansible.builtin.set_fact:
-        server_result:
-          results: >-
-            {{
-              (
-                (gcp_compute_instance_info.results | default([])
-                | map(attribute='resources') | map('default', []) | list | flatten)
-                +
-                (gcp_compute_instance_result.results | default([]))
-              )
-              | selectattr('id', 'defined')
-              | list
-            }}
 
     # Load Balancer
     # This block creates Global External classic proxy Network Load Balancer.

--- a/automation/roles/cloud_resources/tasks/gcp.yml
+++ b/automation/roles/cloud_resources/tasks/gcp.yml
@@ -325,8 +325,10 @@
           results: >-
             {{
               (
-                (gcp_compute_instance_info.results | default([]) | map(attribute='resources') | select('defined') | list | flatten)
-                + (gcp_compute_instance_result.results | default([]))
+                (gcp_compute_instance_info.results | default([])
+                | map(attribute='resources') | map('default', []) | list | flatten)
+                +
+                (gcp_compute_instance_result.results | default([]))
               )
               | selectattr('id', 'defined')
               | list

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -566,6 +566,7 @@
           retries: 3
           http:
             path: "/{{ item }}"
+            tls: "true if patroni_restapi_protocol | lower == 'https' else false"
             status_codes:
               - "200"
         state: present

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -559,7 +559,7 @@
         destination_port: "{{ pgbouncer_listen_port | default(6432) if pgbouncer_install | bool else postgresql_port | default(5432) }}"
         protocol: tcp
         health_check:
-          protocol: "{{ patroni_restapi_protocol }}"
+          protocol: http
           port: "{{ patroni_restapi_port }}"
           interval: 5
           timeout: 2

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -566,7 +566,7 @@
           retries: 3
           http:
             path: "/{{ item }}"
-            tls: "true if patroni_restapi_protocol | lower == 'https' else false"
+            tls: "{{ patroni_restapi_protocol | lower == 'https' }}"
             status_codes:
               - "200"
         state: present

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -464,6 +464,17 @@
         - hetzner_object_storage_secret_key | length > 0
 
     # Server and volume
+    - name: "Hetzner Cloud: Gather information about servers"
+      hetzner.hcloud.server_info:
+        api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
+        name: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      loop: "{{ range(0, server_count | int) | list }}"
+      loop_control:
+        index_var: idx
+        label: "{{ server_name | lower }}{{ '%02d' % (idx + 1) }}"
+      register: server_info
+      failed_when: false
+
     - name: "Hetzner Cloud: Create or modify server"
       hetzner.hcloud.server:
         api_token: "{{ lookup('ansible.builtin.env', 'HCLOUD_API_TOKEN') }}"
@@ -700,8 +711,16 @@
           {{ ip_addresses | default([]) +
             [{
               'public_ip': item.hcloud_server.ipv4_address | default(''),
-              'private_ip': item.hcloud_server.private_networks_info[0].ip | default('')
+              'private_ip': item.hcloud_server.private_networks_info[0].ip | default(''),
+              'new_node': (cluster_scaling | default(false) | bool and item.hcloud_server.id not in existing_server_ids)
             }]
+          }}
+      vars:
+        existing_server_ids: >-
+          {{
+            server_info.results | default([])
+            | map(attribute='hcloud_server_info') | map('default', []) | list | flatten
+            | selectattr('id','defined') | map(attribute='id') | list
           }}
       loop: "{{ server_result.results | selectattr('hcloud_server', 'defined') }}"
       loop_control:

--- a/automation/roles/cloud_resources/tasks/hetzner.yml
+++ b/automation/roles/cloud_resources/tasks/hetzner.yml
@@ -559,7 +559,7 @@
         destination_port: "{{ pgbouncer_listen_port | default(6432) if pgbouncer_install | bool else postgresql_port | default(5432) }}"
         protocol: tcp
         health_check:
-          protocol: http
+          protocol: "{{ patroni_restapi_protocol }}"
           port: "{{ patroni_restapi_port }}"
           interval: 5
           timeout: 2

--- a/automation/roles/cloud_resources/tasks/inventory.yml
+++ b/automation/roles/cloud_resources/tasks/inventory.yml
@@ -1,11 +1,19 @@
 ---
+# Generate in-memory inventory
+
+# Note: for cluster scaling ansible_ssh_private_key_file is used to access existing servers.
+# For new cluster deployment a temporary ssh key is generated if ssh_key_name and ssh_key_content are not provided.
 - name: "Inventory | Set variable: ssh_private_key_file"
   ansible.builtin.set_fact:
-    ssh_private_key_file: "~{{ lookup('env', 'USER') }}/.ssh/{{ tmp_ssh_key_name }}"
+    ssh_private_key_file: >-
+      {{
+        (ansible_ssh_private_key_file | default(''))
+        if (ansible_ssh_private_key_file | default('') | length > 0)
+        else (lookup('env','HOME') ~ '/.ssh/' ~ (tmp_ssh_key_name | default('')))
+      }}
   when:
-    - ssh_key_name is defined
-    - tmp_ssh_key_name is defined
-    - ssh_key_name == tmp_ssh_key_name
+    - (ssh_key_name is defined and tmp_ssh_key_name is defined and ssh_key_name == tmp_ssh_key_name)
+      or (ansible_ssh_private_key_file | default('') | length > 0)
 
 - name: "Inventory | Add host to 'postgres_cluster', 'master' groups"
   ansible.builtin.add_host:

--- a/automation/roles/cloud_resources/tasks/inventory.yml
+++ b/automation/roles/cloud_resources/tasks/inventory.yml
@@ -24,6 +24,7 @@
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
+    bind_address: "{{ item.private_ip }}"
   loop: "{{ [ip_addresses[0]] }}" # add the first item in the list
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -38,6 +39,7 @@
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
+    bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses[1:] }}" # start with the 2nd item of the list
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -51,6 +53,7 @@
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
+    bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses }}"
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -64,6 +67,7 @@
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
+    bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses[:7] }}" # no more than 7 servers for the etcd cluster
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -77,6 +81,7 @@
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
     new_node: "{{ item.new_node | default(omit) }}"
+    bind_address: "{{ item.private_ip }}"
   loop: "{{ ip_addresses }}"
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"

--- a/automation/roles/cloud_resources/tasks/inventory.yml
+++ b/automation/roles/cloud_resources/tasks/inventory.yml
@@ -23,6 +23,7 @@
       - master
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
+    new_node: "{{ item.new_node | default(omit) }}"
   loop: "{{ [ip_addresses[0]] }}" # add the first item in the list
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -36,6 +37,7 @@
       - replica
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
+    new_node: "{{ item.new_node | default(omit) }}"
   loop: "{{ ip_addresses[1:] }}" # start with the 2nd item of the list
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -48,6 +50,7 @@
     group: balancers
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
+    new_node: "{{ item.new_node | default(omit) }}"
   loop: "{{ ip_addresses }}"
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -60,6 +63,7 @@
     group: etcd_cluster
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
+    new_node: "{{ item.new_node | default(omit) }}"
   loop: "{{ ip_addresses[:7] }}" # no more than 7 servers for the etcd cluster
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
@@ -72,6 +76,7 @@
     group: consul_instances
     ansible_ssh_host: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"
     ansible_ssh_private_key_file: "{{ ssh_private_key_file | default(None) }}"
+    new_node: "{{ item.new_node | default(omit) }}"
   loop: "{{ ip_addresses }}"
   loop_control:
     label: "{{ item[server_public_ip | bool | ternary('public_ip', 'private_ip')] }}"

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -72,9 +72,7 @@
 
     - name: Fail if ansible_ssh_private_key_file is not defined
       ansible.builtin.fail:
-        msg: >-
-          Variable 'ansible_ssh_private_key_file' is not defined.
-          Provide --private-key or set ssh_key_content with your SSH public key.
+        msg: "Variable 'ansible_ssh_private_key_file' is not defined. Please provide path to your SSH private key."
       when:
         - ssh_key_content | length < 1
         - ansible_ssh_private_key_file | default('') | length < 1

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -73,9 +73,7 @@
     - name: Fail if ansible_ssh_private_key_file is not defined
       ansible.builtin.fail:
         msg: "Variable 'ansible_ssh_private_key_file' is not defined. Please provide path to your SSH private key."
-      when:
-        - ssh_key_content | length < 1
-        - ansible_ssh_private_key_file | default('') | length < 1
+      when: ansible_ssh_private_key_file | default('') | length < 1
 
     - name: "Set variable: ssh_key_content"
       ansible.builtin.set_fact:

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -80,7 +80,7 @@
         ssh_key_content: >-
           {{
             (pub_slurp.content | default('') | b64decode | trim)
-              if (pub_slurp is defined)
+              if (pub_slurp.content | default('') | length > 0)
               else (pub_from_priv.stdout | trim)
           }}
       when:

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -35,6 +35,7 @@
     - ssh_key_name | length < 1
     - ssh_key_content | length < 1
     - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
+    - not (cluster_scaling | default(false) | bool) # exclude for cluster scaling
 
 # if ssh_key_name and ssh_key_content is not specified (for cluster scaling)
 - block:

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -67,7 +67,7 @@
       when:
         - ssh_key_content | length < 1
         - ansible_ssh_private_key_file | default('') | length > 0
-        - pub_slurp is not defined
+        - lookup('ansible.builtin.fileglob', (ansible_ssh_private_key_file | default('')) + '.pub', errors='ignore') | length < 1
       changed_when: false
 
     - name: Fail if ansible_ssh_private_key_file is not defined

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -79,7 +79,7 @@
       ansible.builtin.set_fact:
         ssh_key_content: >-
           {{
-            (pub_slurp.content | b64decode | trim)
+            (pub_slurp.content | default('') | b64decode | trim)
               if (pub_slurp is defined)
               else (pub_from_priv.stdout | trim)
           }}

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -9,7 +9,7 @@
     (server_image | length < 1 and cloud_provider != 'azure') or
     server_location | length < 1)
 
-# if ssh_key_name is not specified
+# if ssh_key_name and ssh_key_content is not specified (for initial deployment)
 # with each new execution of the playbook, a new temporary ssh key is created
 - block:
     - name: Generate a unique temporary SSH key name
@@ -25,20 +25,71 @@
         ssh_key_comment: "{{ tmp_ssh_key_name }}"
         force: true
       register: tmp_ssh_key_result
+
+    - name: "Set variable: ssh_key_name and ssh_key_content"
+      ansible.builtin.set_fact:
+        ssh_key_name: "{{ tmp_ssh_key_name }}"
+        ssh_key_content: "{{ tmp_ssh_key_result.ssh_public_key }}"
   when:
     - state == 'present'
     - ssh_key_name | length < 1
     - ssh_key_content | length < 1
     - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
 
-# set_fact: ssh_key_name and ssh_key_content
-- name: "Set variable: ssh_key_name and ssh_key_content"
-  ansible.builtin.set_fact:
-    ssh_key_name: "{{ tmp_ssh_key_name }}"
-    ssh_key_content: "{{ tmp_ssh_key_result.ssh_public_key }}"
+# if ssh_key_name and ssh_key_content is not specified (for cluster scaling)
+- block:
+    - name: Generate a unique temporary SSH key name
+      ansible.builtin.set_fact:
+        tmp_ssh_key_name: "ssh_key_tmp_{{ lookup('password', '/dev/null chars=ascii_lowercase length=7') }}"
+      when: (ssh_key_name | default('')) | length < 1
+
+    - name: "Set variable: ssh_key_name"
+      ansible.builtin.set_fact:
+        ssh_key_name: "{{ tmp_ssh_key_name }}"
+      when: tmp_ssh_key_name is defined
+
+    # 1) if there is a .pub nearby, we read it.
+    - name: Read existing SSH public key content
+      ansible.builtin.slurp:
+        src: "{{ (ansible_ssh_private_key_file | default('')) + '.pub' }}"
+      register: pub_slurp
+      when:
+        - ssh_key_content | length < 1
+        - ansible_ssh_private_key_file | default('') | length > 0
+        - lookup('ansible.builtin.fileglob', (ansible_ssh_private_key_file | default('')) + '.pub', errors='ignore') | length > 0
+      changed_when: false
+
+    # 2) otherwise, we extract the pub from the private key.
+    - name: Derive SSH public key from private key
+      ansible.builtin.command: "ssh-keygen -y -f {{ ansible_ssh_private_key_file }}"
+      register: pub_from_priv
+      when:
+        - ssh_key_content | length < 1
+        - ansible_ssh_private_key_file | default('') | length > 0
+        - pub_slurp is not defined
+      changed_when: false
+
+    - name: Fail if ansible_ssh_private_key_file is not defined
+      ansible.builtin.fail:
+        msg: "Variable 'ansible_ssh_private_key_file' is not defined. Provide --private-key or set ssh_key_content with your SSH public key."
+      when:
+        - ssh_key_content | length < 1
+        - ansible_ssh_private_key_file | default('') | length < 1
+
+    - name: "Set variable: ssh_key_content"
+      ansible.builtin.set_fact:
+        ssh_key_content: >-
+          {{
+            (pub_slurp.content | b64decode | trim)
+              if (pub_slurp is defined)
+              else (pub_from_priv.stdout | trim)
+          }}
+      when:
+        - ssh_key_content | length < 1
+        - (pub_slurp is defined or pub_from_priv is defined)
   when:
-    - tmp_ssh_key_result.ssh_public_key is defined
-    - tmp_ssh_key_result.ssh_public_key | length > 0
+    - state == 'present'
+    - cluster_scaling | default(false) | bool
 
 - name: Import tasks for AWS
   ansible.builtin.import_tasks: aws.yml

--- a/automation/roles/cloud_resources/tasks/main.yml
+++ b/automation/roles/cloud_resources/tasks/main.yml
@@ -37,12 +37,12 @@
     - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
     - not (cluster_scaling | default(false) | bool) # exclude for cluster scaling
 
-# if ssh_key_name and ssh_key_content is not specified (for cluster scaling)
+# if ssh_key_name or ssh_key_content is not specified (for cluster scaling)
 - block:
     - name: Generate a unique temporary SSH key name
       ansible.builtin.set_fact:
         tmp_ssh_key_name: "ssh_key_tmp_{{ lookup('password', '/dev/null chars=ascii_lowercase length=7') }}"
-      when: (ssh_key_name | default('')) | length < 1
+      when: ssh_key_name | length < 1
 
     - name: "Set variable: ssh_key_name"
       ansible.builtin.set_fact:
@@ -72,7 +72,9 @@
 
     - name: Fail if ansible_ssh_private_key_file is not defined
       ansible.builtin.fail:
-        msg: "Variable 'ansible_ssh_private_key_file' is not defined. Provide --private-key or set ssh_key_content with your SSH public key."
+        msg: >-
+          Variable 'ansible_ssh_private_key_file' is not defined.
+          Provide --private-key or set ssh_key_content with your SSH public key.
       when:
         - ssh_key_content | length < 1
         - ansible_ssh_private_key_file | default('') | length < 1

--- a/automation/roles/tls_certificate/tasks/main.yml
+++ b/automation/roles/tls_certificate/tasks/main.yml
@@ -16,6 +16,14 @@
       retries: 3
       when: "'python3-cryptography' not in ansible_facts.packages"
 
+    - name: Ensure TLS directory exist
+      ansible.builtin.file:
+        path: "{{ tls_directory }}"
+        state: directory
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
     - block:
         # Check if certificates already exist
         - name: Check if TLS CA cert already exists
@@ -46,7 +54,6 @@
                  else 'consul_tls_cert_regenerate' if tls_group_name | default('') == 'consul_instances'
                  else 'tls_cert_regenerate' }}
           when:
-            - ca_cert.stat.exists | default(false)
             - server_key.stat.exists | default(false)
             - server_cert.stat.exists | default(false)
       when:
@@ -61,9 +68,17 @@
       loop:
         - "{{ generate_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
         - "{{ generate_tls_cert | default(tls_cert | default('server.crt')) }}"
+      when: tls_cert_regenerate | default(false)| bool
+
+    # Clean up existing CA certificates if tls_ca_regenerate is true
+    - name: Clean up existing CA certificates
+      ansible.builtin.file:
+        path: "{{ tls_directory }}/{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item }}"
+        state: absent
+      loop:
         - "{{ generate_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
         - "{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
-      when: tls_cert_regenerate | default(false)| bool
+      when: tls_ca_regenerate | default(false)| bool
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
   when: inventory_hostname in (groups[tls_group_name | default('postgres_cluster')])
@@ -107,19 +122,12 @@
         msg: "SubjectAltName = {{ tls_subject_alt_name | default(generated_subject_alt_name) }}"
 
     ######## Generate CA ########
-    - name: "Ensure TLS directory exist"
-      ansible.builtin.file:
-        path: "{{ tls_directory }}"
-        state: directory
-        owner: "root"
-        group: "root"
-        mode: "0755"
-
     - name: "Generate CA private key"
       community.crypto.openssl_privatekey:
         path: "{{ tls_directory }}/{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
         size: "{{ generate_tls_privatekey_size | default(tls_privatekey_size | default(4096)) }}"
         type: "{{ generate_tls_privatekey_type | default(tls_privatekey_type | default('RSA')) }}"
+      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
 
     - name: "Create CSR for CA certificate"
       community.crypto.openssl_csr_pipe:
@@ -133,6 +141,7 @@
           - keyCertSign
         key_usage_critical: true
       register: ca_csr
+      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
 
     - name: "Create self-signed CA certificate from CSR"
       community.crypto.x509_certificate:
@@ -142,6 +151,7 @@
         provider: "{{ generate_tls_cert_provider | default(tls_cert_provider | default('selfsigned')) }}"
         selfsigned_not_after: "+{{ generate_tls_cert_valid_days | default(tls_cert_valid_days | default(3650)) }}d"
         selfsigned_not_before: "-1d"
+      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
 
     ######## Generate Server cert/key ########
     - name: "Create server private key"
@@ -149,6 +159,7 @@
         path: "{{ tls_directory }}/{{ generate_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
         size: "{{ generate_tls_privatekey_size | default(tls_privatekey_size | default(4096)) }}"
         type: "{{ generate_tls_privatekey_type | default(tls_privatekey_type | default('RSA')) }}"
+      when: not server_key.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
 
     - name: "Create server CSR"
       community.crypto.openssl_csr_pipe:
@@ -165,6 +176,7 @@
           O: "Autobase"
         subject_alt_name: "{{ tls_subject_alt_name | default(generated_subject_alt_name) }}"
       register: csr
+      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
 
     - name: "Sign server certificate with the CA"
       community.crypto.x509_certificate_pipe:
@@ -175,6 +187,7 @@
         ownca_not_after: +{{ generate_tls_cert_valid_days | default(tls_cert_valid_days | default(3650)) }}d
         ownca_not_before: "-1d"
       register: certificate
+      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
 
     - name: "Write server certificate"
       ansible.builtin.copy:
@@ -182,12 +195,11 @@
         content: "{{ certificate.certificate }}"
         group: "{{ generate_tls_group | default('root') }}"
         mode: "0644"
+      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
   when:
     - inventory_hostname == (groups[tls_group_name | default('master')][0])
-    - tls_cert_regenerate | default(false) | bool or
-      (not ca_cert.stat.exists | default(false) or
-      not server_key.stat.exists | default(false) or
-      not server_cert.stat.exists | default(false))
+    - (tls_cert_regenerate | default(false) | bool or tls_ca_regenerate | default(false) | bool) or
+      (not ca_cert.stat.exists | default(false) or not server_key.stat.exists | default(false) or not server_cert.stat.exists | default(false))
   tags: tls, tls_cert_generate

--- a/automation/roles/tls_certificate/tasks/main.yml
+++ b/automation/roles/tls_certificate/tasks/main.yml
@@ -63,22 +63,22 @@
     # Clean up existing certificates if tls_cert_regenerate is true
     - name: Clean up existing certificates
       ansible.builtin.file:
-        path: "{{ tls_directory }}/{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item }}"
+        path: "{{ tls_directory }}/{{ item }}"
         state: absent
       loop:
         - "{{ generate_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
         - "{{ generate_tls_cert | default(tls_cert | default('server.crt')) }}"
-      when: tls_cert_regenerate | default(false)| bool
+      when: tls_cert_regenerate | default(false) | bool
 
     # Clean up existing CA certificates if tls_ca_regenerate is true
     - name: Clean up existing CA certificates
       ansible.builtin.file:
-        path: "{{ tls_directory }}/{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}/{{ item }}"
+        path: "{{ tls_directory }}/{{ item }}"
         state: absent
       loop:
         - "{{ generate_tls_ca_cert | default(tls_ca_cert | default('ca.crt')) }}"
         - "{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
-      when: tls_ca_regenerate | default(false)| bool
+      when: tls_ca_regenerate | default(false) | bool
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
   when: inventory_hostname in (groups[tls_group_name | default('postgres_cluster')])
@@ -115,11 +115,14 @@
             else 'bind_address'
           }}
 
-      when: tls_subject_alt_name | default('') | length < 1
+      when:
+        - tls_subject_alt_name | default('') | length < 1
+        - (need_ca or need_srv_key or need_srv_cert)
 
     - name: "Display Certificate subjectAltName future value"
       ansible.builtin.debug:
         msg: "SubjectAltName = {{ tls_subject_alt_name | default(generated_subject_alt_name) }}"
+      when: tls_subject_alt_name | default(generated_subject_alt_name) | length > 0
 
     ######## Generate CA ########
     - name: "Generate CA private key"
@@ -127,7 +130,7 @@
         path: "{{ tls_directory }}/{{ generate_tls_ca_key | default(tls_ca_key | default('ca.key')) }}"
         size: "{{ generate_tls_privatekey_size | default(tls_privatekey_size | default(4096)) }}"
         type: "{{ generate_tls_privatekey_type | default(tls_privatekey_type | default('RSA')) }}"
-      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
+      when: need_ca
 
     - name: "Create CSR for CA certificate"
       community.crypto.openssl_csr_pipe:
@@ -141,7 +144,7 @@
           - keyCertSign
         key_usage_critical: true
       register: ca_csr
-      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
+      when: need_ca
 
     - name: "Create self-signed CA certificate from CSR"
       community.crypto.x509_certificate:
@@ -151,7 +154,7 @@
         provider: "{{ generate_tls_cert_provider | default(tls_cert_provider | default('selfsigned')) }}"
         selfsigned_not_after: "+{{ generate_tls_cert_valid_days | default(tls_cert_valid_days | default(3650)) }}d"
         selfsigned_not_before: "-1d"
-      when: not ca_cert.stat.exists | default(false) or tls_ca_regenerate | default(false) | bool
+      when: need_ca
 
     ######## Generate Server cert/key ########
     - name: "Create server private key"
@@ -159,7 +162,7 @@
         path: "{{ tls_directory }}/{{ generate_tls_privatekey | default(tls_privatekey | default('server.key')) }}"
         size: "{{ generate_tls_privatekey_size | default(tls_privatekey_size | default(4096)) }}"
         type: "{{ generate_tls_privatekey_type | default(tls_privatekey_type | default('RSA')) }}"
-      when: not server_key.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
+      when: need_srv_key
 
     - name: "Create server CSR"
       community.crypto.openssl_csr_pipe:
@@ -176,7 +179,7 @@
           O: "Autobase"
         subject_alt_name: "{{ tls_subject_alt_name | default(generated_subject_alt_name) }}"
       register: csr
-      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
+      when: need_srv_cert
 
     - name: "Sign server certificate with the CA"
       community.crypto.x509_certificate_pipe:
@@ -187,7 +190,7 @@
         ownca_not_after: +{{ generate_tls_cert_valid_days | default(tls_cert_valid_days | default(3650)) }}d
         ownca_not_before: "-1d"
       register: certificate
-      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
+      when: need_srv_cert
 
     - name: "Write server certificate"
       ansible.builtin.copy:
@@ -195,11 +198,11 @@
         content: "{{ certificate.certificate }}"
         group: "{{ generate_tls_group | default('root') }}"
         mode: "0644"
-      when: not server_cert.stat.exists | default(false) or tls_cert_regenerate | default(false) | bool
+      when: need_srv_cert
   vars:
     tls_directory: "{{ generate_tls_dir | default(tls_dir | default('/etc/tls')) }}"
-  when:
-    - inventory_hostname == (groups[tls_group_name | default('master')][0])
-    - (tls_cert_regenerate | default(false) | bool or tls_ca_regenerate | default(false) | bool) or
-      (not ca_cert.stat.exists | default(false) or not server_key.stat.exists | default(false) or not server_cert.stat.exists | default(false))
+    need_ca: "{{ not (ca_cert is defined and ca_cert.stat.exists | default(false)) or (tls_ca_regenerate | default(false) | bool) }}"
+    need_srv_key: "{{ not (server_key is defined and server_key.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
+    need_srv_cert: "{{ not (server_cert is defined and server_cert.stat.exists | default(false)) or (tls_cert_regenerate | default(false) | bool) }}"
+  when: inventory_hostname == (groups[tls_group_name | default('postgres_cluster')][0])
   tags: tls, tls_cert_generate


### PR DESCRIPTION
This pull request introduces automation for scaling PostgreSQL clusters across supported cloud providers (if `cloud_provider` is defined), enabling seamless addition of new nodes to already deployed cluster.

- [x] AWS
- [x] GCP
- [x] Azure
- [x] DigitalOcean
- [x] Hetzner Cloud

### Playbook

- add_node.yml

### Requirements

The path to the private SSH key must be specified — its public pair should already be added to the deployed cluster nodes. You can define it either via the `ansible_ssh_private_key_file` variable or by using the `--private-key` option.

### Additionally:

1. Added support for `patroni_restapi_protocol` in cloud load balancers, enabling health checks against the Patroni API over HTTPS.
2. Explicitly set `bind_address` in the task that generates the in-memory inventory for clouds to avoid incorrect IP selection on servers with multiple subnets.