### PR TITLE
fix: ignore 'Could not find the requested service' for initial deployment

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,6 +35,12 @@ jobs:
           - distro: almalinux10
             tag: latest
             namespace: glillico
+          - distro: oraclelinux9
+            tag: latest
+            namespace: glillico
+          - distro: oraclelinux10
+            tag: latest
+            namespace: glillico
 
     steps:
       - name: Set TERM environment variable

--- a/automation/roles/patroni/handlers/main.yml
+++ b/automation/roles/patroni/handlers/main.yml
@@ -6,7 +6,6 @@
     enabled: true
     state: reloaded
   register: patroni_reload_result
-  changed_when: patroni_reload_result.rc == 0
   failed_when: false # ignore 'Could not find the requested service' for initial deployment.
   listen: "reload patroni"
 

--- a/automation/roles/patroni/handlers/main.yml
+++ b/automation/roles/patroni/handlers/main.yml
@@ -5,6 +5,9 @@
     name: patroni
     enabled: true
     state: reloaded
+  register: patroni_reload_result
+  changed_when: patroni_reload_result.rc == 0
+  failed_when: false # ignore 'Could not find the requested service' for initial deployment.
   listen: "reload patroni"
 
 - name: Reload postgres


### PR DESCRIPTION
Registers the result of the Patroni reload service, sets changed_when based on the return code, and disables failure on missing service to handle initial deployments more gracefully.

Fixed:

```
  TASK [vitabaks.autobase.patroni : Generate /etc/patroni/patroni.yml] ***********
  changed: [pgnode01]
  changed: [pgnode02]
  changed: [pgnode03]
  fatal: [pgnode01]: FAILED! => {"changed": false, "msg": "Could not find the requested service patroni: host"}
  fatal: [pgnode03]: FAILED! => {"changed": false, "msg": "Could not find the requested service patroni: host"}
  fatal: [pgnode02]: FAILED! => {"changed": false, "msg": "Could not find the requested service patroni: host"}
  
  RUNNING HANDLER [vitabaks.autobase.patroni : Reload patroni service] ***********
```

Job: https://github.com/vitabaks/autobase/actions/runs/17873519454/job/50831194205