### PR TITLE
Add SSL check for Patroni REST API in HAProxy config

### DIFF
--- a/automation/roles/haproxy/templates/haproxy.cfg.j2
+++ b/automation/roles/haproxy/templates/haproxy.cfg.j2
@@ -38,7 +38,7 @@ listen master
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -60,7 +60,7 @@ listen master_direct
     maxconn {{ haproxy_maxconn.master }}
     option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -80,7 +80,7 @@ listen replicas
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -107,7 +107,7 @@ listen replicas_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -127,7 +127,7 @@ listen replicas_sync
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -154,7 +154,7 @@ listen replicas_sync_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
@@ -174,7 +174,7 @@ listen replicas_async
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -201,7 +201,7 @@ listen replicas_async_direct
     {% endif %}
     balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions{% if patroni_restapi_protocol == 'https' %} check-ssl verify none{% endif %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}


### PR DESCRIPTION
Appends 'check-ssl verify none' to HAProxy default-server lines when Patroni REST API protocol is set to 'https'. This ensures proper health checks for secure Patroni endpoints.

Fixes https://github.com/vitabaks/autobase/issues/1276