### PR TITLE
fix: Restrict pg_hba task to postgres_cluster group in add_node.yml

### DIFF
--- a/automation/playbooks/add_node.yml
+++ b/automation/playbooks/add_node.yml
@@ -182,6 +182,7 @@
       when:
         - new_postgres_nodes | default([]) | length > 0
         - not new_node | default(false) | bool
+        - inventory_hostname in groups['postgres_cluster']
 
     - name: Add a new node to new_replica group (in-memory inventory)
       ansible.builtin.add_host:


### PR DESCRIPTION
Added a condition to ensure the task only runs when the inventory_hostname is part of the postgres_cluster group, improving playbook accuracy and preventing unintended execution on non-postgres cluster hosts.

Fixes https://github.com/vitabaks/autobase/issues/1282