### PR TITLE
fix: Force reload postgres after update pg_hba.conf

### DIFF
--- a/automation/roles/patroni/tasks/pg_hba.yml
+++ b/automation/roles/patroni/tasks/pg_hba.yml
@@ -8,3 +8,6 @@
     mode: "0640"
   notify: "reload postgres"
   tags: pg_hba, pg_hba_generate
+
+- name: Make sure handlers are flushed immediately
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Hi

After updating the pg_hba.conf file, you need to immediately reload the postgres configuration without waiting for all the steps to complete. In the add_node.yml playbook, only one pg_hba task is launched, and immediately after launch, we need the pg_hba settings to be applied and begin working.