### PR TITLE
fix: Make sure PostgreSQL unix socket, log and home directory exists

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -374,6 +374,14 @@
   tags: patroni, custom_wal_dir
 
 - block: # when postgresql NOT exists or PITR
+    - name: Prepare PostgreSQL | make sure PostgreSQL home directory "{{ postgresql_home_dir }}"
+      ansible.builtin.file:
+        path: "{{ postgresql_home_dir }}"
+        state: directory
+        owner: postgres
+        group: postgres
+        mode: "0755"
+
     - name: Prepare PostgreSQL | make sure PostgreSQL data directory "{{ postgresql_data_dir }}" exists
       ansible.builtin.file:
         path: "{{ postgresql_data_dir }}"

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -448,6 +448,14 @@
             name: patroni
             state: stopped
 
+        - name: Prepare PostgreSQL | make sure the postgres home directory "{{ postgresql_home_dir }}"
+          ansible.builtin.file:
+            path: "{{ postgresql_home_dir }}"
+            state: directory
+            owner: postgres
+            group: postgres
+            mode: "0755"
+
         - name: Prepare PostgreSQL | make sure the data directory "{{ postgresql_data_dir }}" is empty
           ansible.builtin.file:
             path: "{{ postgresql_data_dir }}"
@@ -458,6 +466,22 @@
           loop:
             - absent
             - directory
+
+        - name: Prepare PostgreSQL | make sure PostgreSQL unix socket directory "{{ postgresql_unix_socket_dir }}" exists
+          ansible.builtin.file:
+            path: "{{ postgresql_unix_socket_dir }}"
+            owner: postgres
+            group: postgres
+            state: directory
+            mode: "02775"
+
+        - name: Prepare PostgreSQL | make sure PostgreSQL log directory "{{ postgresql_log_dir }}" exists
+          ansible.builtin.file:
+            path: "{{ postgresql_log_dir }}"
+            owner: postgres
+            group: postgres
+            state: directory
+            mode: "0700"
 
         - name: Prepare PostgreSQL | make sure the custom WAL directory "{{ postgresql_wal_dir }}" is empty
           ansible.builtin.file:

--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -382,6 +382,22 @@
         state: directory
         mode: "0700"
 
+    - name: Prepare PostgreSQL | make sure PostgreSQL unix socket directory "{{ postgresql_unix_socket_dir }}" exists
+      ansible.builtin.file:
+        path: "{{ postgresql_unix_socket_dir }}"
+        owner: postgres
+        group: postgres
+        state: directory
+        mode: "02775"
+
+    - name: Prepare PostgreSQL | make sure PostgreSQL log directory "{{ postgresql_log_dir }}" exists
+      ansible.builtin.file:
+        path: "{{ postgresql_log_dir }}"
+        owner: postgres
+        group: postgres
+        state: directory
+        mode: "0700"
+
     # for Debian based distros only
     # patroni bootstrap failure is possible if the PostgreSQL config files are missing
     - name: Prepare PostgreSQL | make sure PostgreSQL config directory exists

--- a/automation/roles/pgpass/tasks/main.yml
+++ b/automation/roles/pgpass/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
----
 - name: "Create postgres home directory ({{ postgresql_home_dir }})"
   become: true
   become_user: root

--- a/automation/roles/pgpass/tasks/main.yml
+++ b/automation/roles/pgpass/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+---
+- name: "Create postgres home directory ({{ postgresql_home_dir }})"
+  become: true
+  become_user: root
+  ansible.builtin.file:
+    path: "{{ postgresql_home_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+  when:
+    - postgresql_pgpass is defined
+    - postgresql_pgpass | length > 0
+  tags: pgpass
+
 - name: "Configure a password file ({{ postgresql_home_dir }}/.pgpass)"
   become: true
   become_user: root

--- a/automation/roles/wal_g/tasks/main.yml
+++ b/automation/roles/wal_g/tasks/main.yml
@@ -249,6 +249,15 @@
   when: wal_g_prefetch_dir_create | default(true) | bool
   tags: wal-g, wal_g, wal_g_install
 
+- name: "Create postgres home directory ({{ postgresql_home_dir }})"
+  ansible.builtin.file:
+    path: "{{ postgresql_home_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+  tags: wal-g, wal_g, wal_g_conf
+
 # Configure walg.json
 - name: "Generate conf file {{ postgresql_home_dir }}/.walg.json"
   ansible.builtin.template:


### PR DESCRIPTION
Hi,

while testing autobase, I encountered errors when the Postgres home, logs, or unix socket directory didn't exist or had incorrect permissions and ownership.

These are very rare situations, but I simulated them, and the autobase not correct working.

Therefore, we must check and create these directories in any case.