### PR TITLE
Build and push docker images after release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - "*"
   pull_request:
     branches:
       - master
@@ -56,6 +54,7 @@ jobs:
         env:
           TAG: ${{ env.TAG }}
 
+      # push latest image
       - name: Run Docker push
         if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
         run: make docker-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,17 @@ jobs:
             --token $ANSIBLE_GALAXY_TOKEN
         env:
           ANSIBLE_GALAXY_TOKEN: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}
+
+      - name: Build release image
+        run: make docker-build
+        env:
+          TAG: ${{ env.TAG }}
+
+      - name: Push release image
+        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
+        run: make docker-push
+        env:
+          TAG: ${{ env.TAG }}
+          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           TAG: ${{ env.TAG }}
 
       - name: Push release image
-        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' && github.event_name != 'pull_request' }}
+        if: ${{ env.DOCKER_REGISTRY_USER != '' && env.DOCKER_REGISTRY_PASSWORD != '' }}
         run: make docker-push
         env:
           TAG: ${{ env.TAG }}


### PR DESCRIPTION
Removes tag trigger from docker workflow and adds Docker build and push steps to the release workflow. Ensures Docker images are built and pushed during release.